### PR TITLE
Application insights fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ msbuild.wrn
 /PxApi/internal-nlog-pxapi.txt
 /PxApi/Properties/PublishProfiles
 /PxApi/.config/dotnet-tools.json
+publish/
+PxApi/Logs/
+PxApi/Properties/ServiceDependencies/tk-t-verkko-pxapi-app - Zip Deploy/profile.arm.json
+PxApi/Properties/

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ msbuild.wrn
 /PxApi/.config/dotnet-tools.json
 publish/
 PxApi/Logs/
-PxApi/Properties/ServiceDependencies/tk-t-verkko-pxapi-app - Zip Deploy/profile.arm.json
 PxApi/Properties/

--- a/PxApi.UnitTests/ConfigurationTests/AppSettingsTests.cs
+++ b/PxApi.UnitTests/ConfigurationTests/AppSettingsTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using PxApi.Configuration;
 using PxApi.UnitTests.Utils;
 
@@ -69,6 +70,103 @@ namespace PxApi.UnitTests.ConfigurationTests
                 Assert.That(AppSettings.Active.Cache.DefaultFileListSize, Is.EqualTo(350000));
                 Assert.That(AppSettings.Active.Cache.DefaultMetaSize, Is.EqualTo(200000));
             });
+        }
+
+        [Test]
+        public void AppSettings_WhenApplicationInsightsConfigurationNotProvided_ShouldLoadWithDisabledApplicationInsights()
+        {
+            // Arrange
+            Dictionary<string, string?> configData = TestConfigFactory.Merge(
+                TestConfigFactory.Base(),
+                TestConfigFactory.MountedDb(0, "TestDb", "datasource/root/")
+            );
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+
+            // Act
+            AppSettings.Load(configuration);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(AppSettings.Active.ApplicationInsights.IsEnabled, Is.False);
+                Assert.That(AppSettings.Active.ApplicationInsights.ConnectionString, Is.Null);
+                Assert.That(AppSettings.Active.ApplicationInsights.MinimumLevel, Is.EqualTo(LogLevel.Information));
+                Assert.That(AppSettings.Active.ApplicationInsights.EnableAdaptiveSampling, Is.False);
+            });
+        }
+
+        [Test]
+        public void AppSettings_WhenApplicationInsightsConfigurationProvided_ShouldLoadApplicationInsightsSettings()
+        {
+            // Arrange
+            Dictionary<string, string?> configData = TestConfigFactory.Merge(
+                TestConfigFactory.Base(),
+                TestConfigFactory.MountedDb(0, "TestDb", "datasource/root/"),
+                new Dictionary<string, string?>
+                {
+                    ["ApplicationInsights:ConnectionString"] = "InstrumentationKey=test-key;IngestionEndpoint=https://test.com",
+                    ["ApplicationInsights:MinimumLevel"] = "Debug",
+                    ["ApplicationInsights:EnableAdaptiveSampling"] = "true"
+                }
+            );
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+
+            // Act
+            AppSettings.Load(configuration);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(AppSettings.Active.ApplicationInsights.IsEnabled, Is.True);
+                Assert.That(AppSettings.Active.ApplicationInsights.ConnectionString, Is.EqualTo("InstrumentationKey=test-key;IngestionEndpoint=https://test.com"));
+                Assert.That(AppSettings.Active.ApplicationInsights.MinimumLevel, Is.EqualTo(LogLevel.Debug));
+                Assert.That(AppSettings.Active.ApplicationInsights.EnableAdaptiveSampling, Is.True);
+            });
+        }
+
+        [Test]
+        public void AppSettings_WhenApplicationInsightsEnvironmentVariableSet_ShouldPrioritizeEnvironmentVariable()
+        {
+            // Arrange
+            const string envVarName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+            const string envConnectionString = "InstrumentationKey=env-key;IngestionEndpoint=https://test.com";
+
+            Environment.SetEnvironmentVariable(envVarName, envConnectionString);
+
+            try
+            {
+                Dictionary<string, string?> configData = TestConfigFactory.Merge(
+                    TestConfigFactory.Base(),
+                    TestConfigFactory.MountedDb(0, "TestDb", "datasource/root/"),
+                    new Dictionary<string, string?>
+                    {
+                        ["ApplicationInsights:ConnectionString"] = "InstrumentationKey=config-key;IngestionEndpoint=https://test.com",
+                        ["ApplicationInsights:MinimumLevel"] = "Warning"
+                    }
+                );
+                IConfiguration configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(configData)
+                    .Build();
+
+                // Act
+                AppSettings.Load(configuration);
+
+                // Assert - Environment variable should take priority over config
+                Assert.Multiple(() =>
+                {
+                    Assert.That(AppSettings.Active.ApplicationInsights.IsEnabled, Is.True);
+                    Assert.That(AppSettings.Active.ApplicationInsights.ConnectionString, Is.EqualTo(envConnectionString));
+                    Assert.That(AppSettings.Active.ApplicationInsights.MinimumLevel, Is.EqualTo(LogLevel.Warning)); // Other settings from config should still work
+                });
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVarName, null);
+            }
         }
     }
 }

--- a/PxApi.UnitTests/ConfigurationTests/ApplicationInsightsConfigTests.cs
+++ b/PxApi.UnitTests/ConfigurationTests/ApplicationInsightsConfigTests.cs
@@ -1,0 +1,270 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using PxApi.Configuration;
+
+namespace PxApi.UnitTests.ConfigurationTests
+{
+    [TestFixture]
+    public class ApplicationInsightsConfigTests
+    {
+        [Test]
+        public void Constructor_WhenNoConfigurationProvided_ShouldBeDisabledWithDefaults()
+        {
+            // Arrange
+            Dictionary<string, string?> configData = [];
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+            IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+            // Act
+            ApplicationInsightsConfig config = new(section);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(config.IsEnabled, Is.False);
+                Assert.That(config.ConnectionString, Is.Null);
+                Assert.That(config.MinimumLevel, Is.EqualTo(LogLevel.Information));
+                Assert.That(config.EnableAdaptiveSampling, Is.False);
+            });
+        }
+
+        [Test]
+        public void Constructor_WhenConnectionStringInConfig_ShouldBeEnabledWithConnectionString()
+        {
+            // Arrange
+            Dictionary<string, string?> configData = new()
+            {
+                ["ApplicationInsights:ConnectionString"] = "InstrumentationKey=test-key;IngestionEndpoint=https://test.com"
+            };
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+            IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+            // Act
+            ApplicationInsightsConfig config = new(section);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(config.IsEnabled, Is.True);
+                Assert.That(config.ConnectionString, Is.EqualTo("InstrumentationKey=test-key;IngestionEndpoint=https://test.com"));
+                Assert.That(config.MinimumLevel, Is.EqualTo(LogLevel.Information));
+                Assert.That(config.EnableAdaptiveSampling, Is.False);
+            });
+        }
+
+        [Test]
+        public void Constructor_WhenEnvironmentVariableSet_ShouldUseEnvironmentVariable()
+        {
+            // Arrange
+            const string envVarName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+            const string envConnectionString = "InstrumentationKey=env-key;IngestionEndpoint=https://test.com/env";
+
+            Environment.SetEnvironmentVariable(envVarName, envConnectionString);
+
+            try
+            {
+                Dictionary<string, string?> configData = new()
+                {
+                    ["ApplicationInsights:ConnectionString"] = "InstrumentationKey=config-key;IngestionEndpoint=https://test.com/config"
+                };
+                IConfiguration configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(configData)
+                    .Build();
+                IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+                // Act
+                ApplicationInsightsConfig config = new(section);
+
+                // Assert - Environment variable should take priority
+                Assert.Multiple(() =>
+                {
+                    Assert.That(config.IsEnabled, Is.True);
+                    Assert.That(config.ConnectionString, Is.EqualTo(envConnectionString));
+                });
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVarName, null);
+            }
+        }
+
+        [Test]
+        public void Constructor_WhenOnlyEnvironmentVariableSet_ShouldUseEnvironmentVariable()
+        {
+            // Arrange
+            const string envVarName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+            const string envConnectionString = "InstrumentationKey=env-only-key;IngestionEndpoint=https://env-only.com";
+
+            Environment.SetEnvironmentVariable(envVarName, envConnectionString);
+
+            try
+            {
+                Dictionary<string, string?> configData = [];
+                IConfiguration configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(configData)
+                    .Build();
+                IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+                // Act
+                ApplicationInsightsConfig config = new(section);
+
+                // Assert
+                Assert.Multiple(() =>
+                {
+                    Assert.That(config.IsEnabled, Is.True);
+                    Assert.That(config.ConnectionString, Is.EqualTo(envConnectionString));
+                });
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVarName, null);
+            }
+        }
+
+        [Test]
+        public void Constructor_WhenEmptyConnectionStringInConfig_ShouldBeDisabled()
+        {
+            // Arrange
+            Dictionary<string, string?> configData = new()
+            {
+                ["ApplicationInsights:ConnectionString"] = ""
+            };
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+            IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+            // Act
+            ApplicationInsightsConfig config = new(section);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(config.IsEnabled, Is.False);
+                Assert.That(config.ConnectionString, Is.EqualTo(""));
+            });
+        }
+
+        [Test]
+        public void Constructor_WhenMinimumLevelSet_ShouldUseConfiguredLevel()
+        {
+            // Arrange
+            Dictionary<string, string?> configData = new()
+            {
+                ["ApplicationInsights:ConnectionString"] = "InstrumentationKey=test-key",
+                ["ApplicationInsights:MinimumLevel"] = "Debug"
+            };
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+            IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+            // Act
+            ApplicationInsightsConfig config = new(section);
+
+            // Assert
+            Assert.That(config.MinimumLevel, Is.EqualTo(LogLevel.Debug));
+        }
+
+        [Test]
+        public void Constructor_WhenInvalidMinimumLevel_ShouldUseDefaultInformation()
+        {
+            // Arrange
+            Dictionary<string, string?> configData = new()
+            {
+                ["ApplicationInsights:ConnectionString"] = "InstrumentationKey=test-key",
+                ["ApplicationInsights:MinimumLevel"] = "InvalidLevel"
+            };
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+            IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+            // Act
+            ApplicationInsightsConfig config = new(section);
+
+            // Assert
+            Assert.That(config.MinimumLevel, Is.EqualTo(LogLevel.Information));
+        }
+
+        [Test]
+        public void Constructor_WhenAdaptiveSamplingEnabled_ShouldUseConfiguredValue()
+        {
+            // Arrange
+            Dictionary<string, string?> configData = new()
+            {
+                ["ApplicationInsights:ConnectionString"] = "InstrumentationKey=test-key",
+                ["ApplicationInsights:EnableAdaptiveSampling"] = "true"
+            };
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+            IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+            // Act
+            ApplicationInsightsConfig config = new(section);
+
+            // Assert
+            Assert.That(config.EnableAdaptiveSampling, Is.True);
+        }
+
+        [Test]
+        public void Constructor_WhenAllSettingsProvided_ShouldUseAllConfiguredValues()
+        {
+            // Arrange
+            Dictionary<string, string?> configData = new()
+            {
+                ["ApplicationInsights:ConnectionString"] = "InstrumentationKey=full-test-key",
+                ["ApplicationInsights:MinimumLevel"] = "Warning",
+                ["ApplicationInsights:EnableAdaptiveSampling"] = "true"
+            };
+            IConfiguration configuration = new ConfigurationBuilder()
+                 .AddInMemoryCollection(configData)
+                 .Build();
+            IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+            // Act
+            ApplicationInsightsConfig config = new(section);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(config.IsEnabled, Is.True);
+                Assert.That(config.ConnectionString, Is.EqualTo("InstrumentationKey=full-test-key"));
+                Assert.That(config.MinimumLevel, Is.EqualTo(LogLevel.Warning));
+                Assert.That(config.EnableAdaptiveSampling, Is.True);
+            });
+        }
+
+        [TestCase("Debug", LogLevel.Debug)]
+        [TestCase("Information", LogLevel.Information)]
+        [TestCase("Warning", LogLevel.Warning)]
+        [TestCase("Error", LogLevel.Error)]
+        [TestCase("Critical", LogLevel.Critical)]
+        [TestCase("debug", LogLevel.Debug)] // Case insensitive
+        [TestCase("INFORMATION", LogLevel.Information)] // Case insensitive
+        public void Constructor_WhenValidMinimumLevelProvided_ShouldParseCorrectly(string levelString, LogLevel expectedLevel)
+        {
+            // Arrange
+            Dictionary<string, string?> configData = new()
+            {
+                ["ApplicationInsights:ConnectionString"] = "InstrumentationKey=test-key",
+                ["ApplicationInsights:MinimumLevel"] = levelString
+            };
+            IConfiguration configuration = new ConfigurationBuilder()
+                 .AddInMemoryCollection(configData)
+                 .Build();
+            IConfigurationSection section = configuration.GetSection("ApplicationInsights");
+
+            // Act
+            ApplicationInsightsConfig config = new(section);
+
+            // Assert
+            Assert.That(config.MinimumLevel, Is.EqualTo(expectedLevel));
+        }
+    }
+}

--- a/PxApi/Configuration/AppSettings.cs
+++ b/PxApi/Configuration/AppSettings.cs
@@ -49,6 +49,11 @@ namespace PxApi.Configuration
         public LocalizationConfig Localization { get; }
 
         /// <summary>
+        /// Application Insights configuration for telemetry and logging.
+        /// </summary>
+        public ApplicationInsightsConfig ApplicationInsights { get; }
+
+        /// <summary>
         /// The currently active configuration for the application.
         /// </summary>
         public static AppSettings Active
@@ -92,6 +97,7 @@ namespace PxApi.Configuration
             Cache = new MemoryCacheConfig(configuration.GetSection(nameof(Cache)));
             OpenApi = new OpenApiConfig(configuration.GetSection(nameof(OpenApi)));
             Localization = new LocalizationConfig(configuration.GetSection(nameof(Localization)));
+            ApplicationInsights = new ApplicationInsightsConfig(configuration.GetSection(nameof(ApplicationInsights)));
         }
 
         /// <summary>

--- a/PxApi/Configuration/ApplicationInsightsConfig.cs
+++ b/PxApi/Configuration/ApplicationInsightsConfig.cs
@@ -29,15 +29,12 @@ namespace PxApi.Configuration
         /// <param name="configurationSection">Configuration section containing ApplicationInsights settings.</param>
         public ApplicationInsightsConfig(IConfigurationSection configurationSection)
         {
-            // Check environment variable first, then config
             ConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")
                ?? configurationSection.GetValue<string>(nameof(ConnectionString));
 
-            // Parse minimum level, default to Information
             string levelString = configurationSection.GetValue<string>(nameof(MinimumLevel)) ?? "Information";
             MinimumLevel = Enum.TryParse<LogLevel>(levelString, true, out LogLevel parsedLevel) ? parsedLevel : LogLevel.Information;
 
-            // Get adaptive sampling setting, default to false
             EnableAdaptiveSampling = configurationSection.GetValue<bool>(nameof(EnableAdaptiveSampling), false);
         }
 

--- a/PxApi/Configuration/ApplicationInsightsConfig.cs
+++ b/PxApi/Configuration/ApplicationInsightsConfig.cs
@@ -1,0 +1,49 @@
+namespace PxApi.Configuration
+{
+    /// <summary>
+    /// Configuration for Application Insights integration.
+    /// </summary>
+    public class ApplicationInsightsConfig
+    {
+        /// <summary>
+        /// Application Insights connection string.
+        /// Can be overridden by the APPLICATIONINSIGHTS_CONNECTION_STRING environment variable.
+        /// </summary>
+        public string? ConnectionString { get; }
+
+        /// <summary>
+        /// Minimum log level to send to Application Insights.
+        /// Defaults to Information if not specified.
+        /// </summary>
+        public LogLevel MinimumLevel { get; }
+
+        /// <summary>
+        /// Whether adaptive sampling is enabled.
+        /// Defaults to false to ensure all configured logs are captured.
+        /// </summary>
+        public bool EnableAdaptiveSampling { get; }
+
+        /// <summary>
+        /// Initializes ApplicationInsights configuration from the provided configuration section.
+        /// </summary>
+        /// <param name="configurationSection">Configuration section containing ApplicationInsights settings.</param>
+        public ApplicationInsightsConfig(IConfigurationSection configurationSection)
+        {
+            // Check environment variable first, then config
+            ConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")
+               ?? configurationSection.GetValue<string>(nameof(ConnectionString));
+
+            // Parse minimum level, default to Information
+            string levelString = configurationSection.GetValue<string>(nameof(MinimumLevel)) ?? "Information";
+            MinimumLevel = Enum.TryParse<LogLevel>(levelString, true, out LogLevel parsedLevel) ? parsedLevel : LogLevel.Information;
+
+            // Get adaptive sampling setting, default to false
+            EnableAdaptiveSampling = configurationSection.GetValue<bool>(nameof(EnableAdaptiveSampling), false);
+        }
+
+        /// <summary>
+        /// Returns true if Application Insights is configured (connection string is available).
+        /// </summary>
+        public bool IsEnabled => !string.IsNullOrEmpty(ConnectionString);
+    }
+}

--- a/PxApi/Program.cs
+++ b/PxApi/Program.cs
@@ -1,19 +1,21 @@
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.ApplicationInsights;
 using Microsoft.FeatureManagement;
 using Microsoft.OpenApi.Models;
-using NLog.Web;
 using NLog;
+using NLog.Web;
 using PxApi.Caching;
 using PxApi.Configuration;
 using PxApi.DataSources;
+using PxApi.Exceptions;
+using PxApi.OpenApi;
+using PxApi.OpenApi.DocumentFilters;
+using PxApi.OpenApi.SchemaFilters;
+using PxApi.Services;
 using PxApi.Utilities;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using PxApi.OpenApi.DocumentFilters;
-using PxApi.OpenApi.SchemaFilters;
-using PxApi.OpenApi;
-using PxApi.Services;
-using PxApi.Exceptions;
 
 namespace PxApi
 {
@@ -95,7 +97,24 @@ namespace PxApi
         {
             // Add feature management first and API explorer conventions to control Swagger visibility
             serviceCollection.AddFeatureManagement();
-            
+
+            // Configure Application Insights if connection string is available
+            ApplicationInsightsConfig aiConfig = AppSettings.Active.ApplicationInsights;
+            if (aiConfig.IsEnabled)
+            {
+                ApplicationInsightsServiceOptions aiOptions = new()
+                {
+                    ConnectionString = aiConfig.ConnectionString,
+                    EnableAdaptiveSampling = aiConfig.EnableAdaptiveSampling
+                };
+                serviceCollection.AddApplicationInsightsTelemetry(aiOptions);
+
+                serviceCollection.Configure<LoggerFilterOptions>(options =>
+                {
+                    options.AddFilter<ApplicationInsightsLoggerProvider>("", aiConfig.MinimumLevel);
+                });
+            }
+
             serviceCollection.AddControllers(options =>
             {
                 options.Conventions.Add(new ApiExplorerConventionsFactory());

--- a/PxApi/PxApi.csproj
+++ b/PxApi/PxApi.csproj
@@ -19,6 +19,7 @@
    <PackageReference Include="Azure.Identity" Version="1.14.2" />
    <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.23.0" />
+   <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.3.0" />
    <PackageReference Include="NLog" Version="5.3.4" />

--- a/PxApi/appsettings.deploy.json
+++ b/PxApi/appsettings.deploy.json
@@ -24,6 +24,11 @@
       "en"
     ]
   },
+  "ApplicationInsights": {
+    "ConnectionString": "",
+    "MinimumLevel": "Information",
+    "EnableAdaptiveSampling": false
+  },
   "DataBases": [
     {
       "Type": "Mounted",

--- a/PxApi/nlog.config
+++ b/PxApi/nlog.config
@@ -12,7 +12,6 @@
 	<variable name="logsPath" value="${configsetting:item=LogOptions.Folder}" />
 	<variable name="textLogEnabled" value="${when:when='${configsetting:item=LogOptions.Folder}'!='':inner=true:else=false}" />
 	<variable name="auditEnabled" value="${configsetting:item=LogOptions.AuditLog.Enabled:default=false}" />
-	<variable name="aiEnabled" value="${when:when='${configsetting:item=LogOptions.ApplicationInsightsConnectionString}'!='':inner=true:else=false}" />
 
 	<targets>
 		<!-- Regular application logs -->
@@ -36,23 +35,17 @@
 				<attribute name="Path" layout="${aspnet-request-url}" />
 			</layout>
 		</target>
-
-		<target xsi:type="ApplicationInsightsTarget" name="aiTarget">
-			<connectionString>${configsetting:item=LogOptions.ApplicationInsightsConnectionString}</connectionString>
-		</target>
 	</targets>
 
 	<rules>
-		<!-- Audit logs go to the audit target (correct namespace) -->
-		<logger name="PxApi.Services.AuditLogService" minlevel="Info" writeTo="audit" enabled="${when:when='${auditEnabled}'=='true'}" final="true" />
-		<!-- Application Insights logs go to the AI target -->
-		<logger name="*" minlevel="Info" writeTo="aiTarget" enabled="${when:when='${aiEnabled}'=='true'}" final="true" />
-
-		<!-- Skip Microsoft and System logs -->
+		<!-- Skip Microsoft and System logs early -->
 		<logger name="Microsoft.*" maxlevel="Fatal" final="true" />
 		<logger name="System.Net.Http.*" maxlevel="Fatal" final="true" />
 
-		<!-- All other logs go to the regular target -->
-		<logger name="*" minlevel="${configsetting:item=LogOptions.Level}" writeTo="own" enabled="${when:when='${textLogEnabled}'=='true'}" final="true" />
+		<!-- Audit logs go to the audit target (correct namespace) -->
+		<logger name="PxApi.Services.AuditLogService" minlevel="Info" writeTo="audit" enabled="${when:when='${auditEnabled}'=='true'}" final="true" />
+		
+		<!-- All other application logs go to file target -->
+		<logger name="*" minlevel="${configsetting:item=LogOptions.Level}" writeTo="own" enabled="${when:when='${textLogEnabled}'=='true'}" />
 	</rules>
 </nlog>

--- a/PxApi/nlog.config
+++ b/PxApi/nlog.config
@@ -46,6 +46,6 @@
 		<logger name="PxApi.Services.AuditLogService" minlevel="Info" writeTo="audit" enabled="${when:when='${auditEnabled}'=='true'}" final="true" />
 		
 		<!-- All other application logs go to file target -->
-		<logger name="*" minlevel="${configsetting:item=LogOptions.Level}" writeTo="own" enabled="${when:when='${textLogEnabled}'=='true'}" />
+		<logger name="*" minlevel="${configsetting:item=LogOptions.Level}" writeTo="own" enabled="${when:when='${textLogEnabled}'=='true'}" final="true" />
 	</rules>
 </nlog>

--- a/docs/README.md
+++ b/docs/README.md
@@ -168,6 +168,10 @@ Provided via `appsettings.json`.
 
 Key sections:
 - `RootUrl` Base absolute URL used for generated links & OpenAPI servers.
+- `ApplicationInsights` Application Insights telemetry and logging configuration:
+  - `ConnectionString` Application Insights connection string (can be overridden by `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable)
+  - `MinimumLevel` Minimum log level to send to Application Insights (Debug, Information, Warning, Error, Critical). Defaults to Information.
+  - `EnableAdaptiveSampling` Whether to enable adaptive sampling. Defaults to false to ensure all configured logs are captured.
 - `DataBases` Array of database definitions:
   - `Type` One of `Mounted`, `FileShare`, `BlobStorage`
   - `Id` Unique id
@@ -186,6 +190,45 @@ Key sections:
 - `FeatureManagement` Feature flags (e.g. `CacheController`)
 - `Authentication` Controller-specific API key settings - see Authentication section below
 - `OpenApi` Metadata (contact, license) for Swagger document
+- `LogOptions` NLog file logging configuration:
+  - `Folder` Directory for log files (empty disables file logging)
+  - `SysId` System identifier for log entries
+  - `Level` Minimum log level for file logging (Debug, Information, Warning, Error, Critical)
+  - `AuditLog` Audit logging settings
+
+### Application Insights Configuration
+
+Application Insights integration is optional and automatically enabled when a connection string is provided.
+
+```json
+{
+  "ApplicationInsights": {
+    "ConnectionString": "InstrumentationKey=your-key;IngestionEndpoint=https://...",
+    "MinimumLevel": "Information",
+    "EnableAdaptiveSampling": false
+  }
+}
+```
+
+**Configuration Sources (in order of priority):**
+1. `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable
+2. `ApplicationInsights:ConnectionString` in appsettings.json
+
+**Settings:**
+- **ConnectionString**: Application Insights connection string. If empty or missing, Application Insights is disabled.
+- **MinimumLevel**: Minimum log level to send (Debug, Information, Warning, Error, Critical). Defaults to Information.
+- **EnableAdaptiveSampling**: When true, Application Insights may drop some logs to reduce volume. Defaults to false to ensure all configured logs are captured.
+
+**Environment Variable Configuration:**
+```bash
+# Enable Application Insights via environment variable
+APPLICATIONINSIGHTS_CONNECTION_STRING="InstrumentationKey=your-key;IngestionEndpoint=https://..."
+```
+
+**Logging Architecture:**
+- **File Logs**: Controlled by NLog configuration and `LogOptions` section
+- **Application Insights**: Controlled by Application Insights SDK and `ApplicationInsights` section
+- Both systems operate independently - you can have file logging without AI, AI without file logging, or both together
 
 ## Authentication
 


### PR DESCRIPTION
Removed application insights target from nlog.config since after testing it didn't affect anything.
Application insights configuration now supports using environment variable instead of appsettings property.