### PR TITLE
Removed a test for application insight configuration that could have conflicted with the system env

### DIFF
--- a/PxApi.UnitTests/ConfigurationTests/AppSettingsTests.cs
+++ b/PxApi.UnitTests/ConfigurationTests/AppSettingsTests.cs
@@ -73,31 +73,6 @@ namespace PxApi.UnitTests.ConfigurationTests
         }
 
         [Test]
-        public void AppSettings_WhenApplicationInsightsConfigurationNotProvided_ShouldLoadWithDisabledApplicationInsights()
-        {
-            // Arrange
-            Dictionary<string, string?> configData = TestConfigFactory.Merge(
-                TestConfigFactory.Base(),
-                TestConfigFactory.MountedDb(0, "TestDb", "datasource/root/")
-            );
-            IConfiguration configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(configData)
-                .Build();
-
-            // Act
-            AppSettings.Load(configuration);
-
-            // Assert
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(AppSettings.Active.ApplicationInsights.IsEnabled, Is.False);
-                Assert.That(AppSettings.Active.ApplicationInsights.ConnectionString, Is.Null);
-                Assert.That(AppSettings.Active.ApplicationInsights.MinimumLevel, Is.EqualTo(LogLevel.Information));
-                Assert.That(AppSettings.Active.ApplicationInsights.EnableAdaptiveSampling, Is.False);
-            }
-        }
-
-        [Test]
         public void AppSettings_WhenApplicationInsightsConfigurationProvided_ShouldLoadApplicationInsightsSettings()
         {
             // Arrange


### PR DESCRIPTION
The same functionality is tested in the dedicated applicaton insights config tests, so the coverage should not be reduced.