### PR TITLE
Add version check script and CI job for PxApi changes

### DIFF
--- a/.github/scripts/check_version_changes.sh
+++ b/.github/scripts/check_version_changes.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-versionNumber=$(grep '<VersionPrefix>' ./PxApi/PxApi.csproj | grep -o "[0-9]*\.[0-9]*\.[0-9]*")
+versionNumber=$(grep '<Version>' ./PxApi/PxApi.csproj | grep -o "[0-9]*\.[0-9]*\.[0-9]*")
 
 git fetch origin dev --quiet
 
-versionInDev=$(git show origin/dev:PxApi/PxApi.csproj | grep '<VersionPrefix>' | grep -o "[0-9]*\.[0-9]*\.[0-9]*")
+versionInDev=$(git show origin/dev:PxApi/PxApi.csproj | grep '<Version>' | grep -o "[0-9]*\.[0-9]*\.[0-9]*")
 
 echo "Version: This branch $versionNumber, dev branch $versionInDev"
 

--- a/.github/scripts/check_version_changes.sh
+++ b/.github/scripts/check_version_changes.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+versionNumber=$(grep '<VersionPrefix>' ./PxApi/PxApi.csproj | grep -o "[0-9]*\.[0-9]*\.[0-9]*")
+
+git fetch origin dev --quiet
+
+versionInDev=$(git show origin/dev:PxApi/PxApi.csproj | grep '<VersionPrefix>' | grep -o "[0-9]*\.[0-9]*\.[0-9]*")
+
+echo "Version: This branch $versionNumber, dev branch $versionInDev"
+
+smallerOrEqual() {
+	if [[ $1 == $2 ]]
+	then
+		return 0
+	fi
+
+	local oldIFS=$IFS
+	IFS='.'
+	read -ra in1Vers <<< "$1"
+	read -ra in2Vers <<< "$2"
+	IFS=$oldIFS
+
+	for i in 0 1 2
+	do
+		if ((10#${in1Vers[i]} > 10#${in2Vers[i]}))
+		then
+			return 1
+		fi
+	done
+	return 0
+}
+
+if ! git diff --quiet origin/dev HEAD PxApi; then
+	if smallerOrEqual $versionNumber $versionInDev
+	then
+		echo "Version number needs to be updated."
+		exit 1
+	fi
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,18 @@ env:
   CI: false
 
 jobs:
+  check-version:
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'dev' && github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check project version
+        run: bash .github/scripts/check_version_changes.sh
+
   build:
     strategy:
       matrix:
@@ -31,19 +43,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up dotnet 
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
-      - name: Install backend dependencies
+      - name: Install dependencies
         run: dotnet restore
 
-      - name: Build backend
+      - name: Build
         run: dotnet build --no-restore --verbosity normal --configuration ${{ matrix.configuration }} /p:TargetFramework=net10.0
 
-      - name: Run backend tests
+      - name: Run tests
         run: dotnet test --no-restore --verbosity normal --configuration ${{ matrix.configuration }} /p:TargetFramework=net10.0

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -11,13 +11,7 @@ on:
 
 jobs:
   sonar:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        dotnet-version: ['10.x']
-        configuration: [ 'Debug' ]
-        
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
@@ -50,11 +44,11 @@ jobs:
             /d:sonar.cs.vscoveragexml.reportsPaths=**/coverage.xml
             /d:sonar.scanner.scanAll=false
 
-      - name: Build backend
-        run: dotnet build --configuration ${{ matrix.configuration }} /p:TargetFramework=net10.0
+      - name: Build
+        run: dotnet build --configuration Debug /p:TargetFramework=net10.0
 
       - name: Run coverage test
-        run: dotnet-coverage collect "dotnet test --configuration ${{ matrix.configuration }} --logger trx /p:TargetFramework=net10.0" -f xml -o coverage.xml
+        run: dotnet-coverage collect "dotnet test --configuration Debug --logger trx /p:TargetFramework=net10.0" -f xml -o coverage.xml
         
       - name: End SonarScanner
         run: dotnet sonarscanner end /d:sonar.token=${{ secrets.SONAR_TOKEN }}

--- a/PxApi.sln
+++ b/PxApi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.4.11605.240 stable
+VisualStudioVersion = 18.4.11605.240
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PxApi", "PxApi\PxApi.csproj", "{523A3458-932D-4936-BC19-0A6175965B19}"
 EndProject
@@ -32,6 +32,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\sonar.yml = .github\workflows\sonar.yml
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{11A8C8BB-BE45-4CF4-BBA9-80E0B0E862EC}"
+	ProjectSection(SolutionItems) = preProject
+		.github\scripts\check_version_changes.sh = .github\scripts\check_version_changes.sh
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +57,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{5C6E13B8-2410-44BA-98F5-8830DA756959} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{11A8C8BB-BE45-4CF4-BBA9-80E0B0E862EC} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5B90BE07-D6C0-4E62-9F2B-7CCDF785ACFB}

--- a/PxApi/PxApi.csproj
+++ b/PxApi/PxApi.csproj
@@ -5,7 +5,7 @@
    <Nullable>enable</Nullable>
    <ImplicitUsings>enable</ImplicitUsings>
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-   <Version>0.2.0</Version>
+   <Version>0.3.0</Version>
  </PropertyGroup>
 
  <ItemGroup>


### PR DESCRIPTION
Introduced .github/scripts/check_version_changes.sh to enforce version bump in PxApi/PxApi.csproj when PxApi is modified. Integrated this check as a dedicated job in ci.yml for PRs targeting dev (excluding dependabot). Refactored sonar pipeline to no longer trigger multiple scans.