### PR TITLE
[Fix] Add audit logging for 404s in controllers and tests

### DIFF
--- a/PxApi.UnitTests/ControllerTests/DataControllerTests.cs
+++ b/PxApi.UnitTests/ControllerTests/DataControllerTests.cs
@@ -206,6 +206,40 @@ namespace PxApi.UnitTests.ControllerTests
         }
 
         [Test]
+        public async Task GetDataAsync_MissingDatabase_ReturnsNotFound()
+        {
+            // Arrange
+            string database = "nonexistent";
+            string table = "testtable";
+            string[] filters = ["dim0:code=value1"];
+
+            _cachedDbConnector.Setup(x => x.GetDataBaseReference(It.Is<string>(s => s == database))).Returns((DataBaseRef?)null);
+
+            // Act
+            IActionResult result = await _controller.GetDataAsync(database, table, filters);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+        }
+
+        [Test]
+        public async Task GetDataAsync_MissingDatabase_LogsAuditEvent()
+        {
+            // Arrange
+            string database = "nonexistent";
+            string table = "testtable";
+            string[] filters = ["dim0:code=value1"];
+
+            _cachedDbConnector.Setup(x => x.GetDataBaseReference(It.Is<string>(s => s == database))).Returns((DataBaseRef?)null);
+
+            // Act
+            await _controller.GetDataAsync(database, table, filters);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
         public async Task GetDataAsync_MissingTable_ReturnsNotFound()
         {
             // Arrange
@@ -222,6 +256,25 @@ namespace PxApi.UnitTests.ControllerTests
 
             // Assert
             Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+        }
+
+        [Test]
+        public async Task GetDataAsync_MissingTable_LogsAuditEvent()
+        {
+            // Arrange
+            string database = "testdb";
+            string table = "nonexistent";
+            string[] filters = ["dim0:code=value1"];
+
+            DataBaseRef dataBaseRef = DataBaseRef.Create(database);
+            _cachedDbConnector.Setup(x => x.GetDataBaseReference(It.Is<string>(s => s == database))).Returns(dataBaseRef);
+            _cachedDbConnector.Setup(x => x.GetFileReferenceCachedAsync(It.Is<string>(s => s == table), dataBaseRef, CancellationToken.None)).ReturnsAsync((PxFileRef?)null);
+
+            // Act
+            await _controller.GetDataAsync(database, table, filters);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
         }
 
         #endregion
@@ -336,6 +389,60 @@ namespace PxApi.UnitTests.ControllerTests
 
             // Assert
             Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+        }
+
+        [Test]
+        public async Task PostDataAsync_ValidRequest_LogsAuditEvent()
+        {
+            // Arrange
+            string database = "testdb";
+            string table = "testtable";
+            Dictionary<string, Filter> query = new() { { "dim0-code", new CodeFilter(["dim0-value1-code"]) } };
+
+            SetupMockDataSourceForValidRequest(database, table);
+            _controller.ControllerContext.HttpContext.Request.Headers.Accept = "application/json";
+
+            // Act
+            await _controller.PostDataAsync(database, table, query);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
+        public async Task PostDataAsync_MissingDatabase_LogsAuditEvent()
+        {
+            // Arrange
+            string database = "nonexistent";
+            string table = "testtable";
+            Dictionary<string, Filter> query = new() { { "dim0-code", new CodeFilter(["dim0-value1-code"]) } };
+
+            _cachedDbConnector.Setup(x => x.GetDataBaseReference(It.Is<string>(s => s == database))).Returns((DataBaseRef?)null);
+
+            // Act
+            await _controller.PostDataAsync(database, table, query);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
+        public async Task PostDataAsync_MissingTable_LogsAuditEvent()
+        {
+            // Arrange
+            string database = "testdb";
+            string table = "nonexistent";
+            Dictionary<string, Filter> query = new() { { "dim0-code", new CodeFilter(["dim0-value1-code"]) } };
+
+            DataBaseRef dataBaseRef = DataBaseRef.Create(database);
+            _cachedDbConnector.Setup(x => x.GetDataBaseReference(It.Is<string>(s => s == database))).Returns(dataBaseRef);
+            _cachedDbConnector.Setup(x => x.GetFileReferenceCachedAsync(It.Is<string>(s => s == table), dataBaseRef, CancellationToken.None)).ReturnsAsync((PxFileRef?)null);
+
+            // Act
+            await _controller.PostDataAsync(database, table, query);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
         }
 
         #endregion
@@ -807,6 +914,92 @@ namespace PxApi.UnitTests.ControllerTests
             }
             _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
         }
+
+        [Test]
+        public async Task HeadDataAsync_DatabaseNotFound_ReturnsNotFound()
+        {
+            // Arrange
+            string database = "nonexistent";
+            string table = "testtable";
+
+            _cachedDbConnector.Setup(x => x.GetDataBaseReference(It.Is<string>(s => s == database))).Returns((DataBaseRef?)null);
+
+            // Act
+            IActionResult result = await _controller.HeadDataAsync(database, table);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<NotFoundResult>());
+        }
+
+        [Test]
+        public async Task HeadDataAsync_DatabaseNotFound_LogsAuditEvent()
+        {
+            // Arrange
+            string database = "nonexistent";
+            string table = "testtable";
+
+            _cachedDbConnector.Setup(x => x.GetDataBaseReference(It.Is<string>(s => s == database))).Returns((DataBaseRef?)null);
+
+            // Act
+            await _controller.HeadDataAsync(database, table);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
+        public async Task HeadDataAsync_TableNotFound_ReturnsNotFound()
+        {
+            // Arrange
+            string database = "testdb";
+            string table = "nonexistent";
+
+            DataBaseRef dataBaseRef = DataBaseRef.Create(database);
+            _cachedDbConnector.Setup(x => x.GetDataBaseReference(It.Is<string>(s => s == database))).Returns(dataBaseRef);
+            _cachedDbConnector.Setup(x => x.GetFileReferenceCachedAsync(It.Is<string>(s => s == table), dataBaseRef, CancellationToken.None)).ReturnsAsync((PxFileRef?)null);
+
+            // Act
+            IActionResult result = await _controller.HeadDataAsync(database, table);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<NotFoundResult>());
+        }
+
+        [Test]
+        public async Task HeadDataAsync_TableNotFound_LogsAuditEvent()
+        {
+            // Arrange
+            string database = "testdb";
+            string table = "nonexistent";
+
+            DataBaseRef dataBaseRef = DataBaseRef.Create(database);
+            _cachedDbConnector.Setup(x => x.GetDataBaseReference(It.Is<string>(s => s == database))).Returns(dataBaseRef);
+            _cachedDbConnector.Setup(x => x.GetFileReferenceCachedAsync(It.Is<string>(s => s == table), dataBaseRef, CancellationToken.None)).ReturnsAsync((PxFileRef?)null);
+
+            // Act
+            await _controller.HeadDataAsync(database, table);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
+        public async Task HeadDataAsync_InvalidLanguage_ReturnsBadRequest()
+        {
+            // Arrange
+            string database = "testdb";
+            string table = "testtable";
+            string lang = "invalid";
+
+            SetupMockDataSourceForValidRequest(database, table);
+
+            // Act
+            IActionResult result = await _controller.HeadDataAsync(database, table, lang);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<BadRequestResult>());
+        }
+
         #endregion
 
         #region CSV Tests

--- a/PxApi.UnitTests/ControllerTests/MetadataControllerTest.cs
+++ b/PxApi.UnitTests/ControllerTests/MetadataControllerTest.cs
@@ -92,6 +92,39 @@ namespace PxApi.UnitTests.ControllerTests
         }
 
         [Test]
+        public async Task GetTableMetadataById_DatabaseNotFound_LogsAuditEvent()
+        {
+            // Arrange
+            string databaseId = "nonexistentdb";
+            string tableId = "table1";
+
+            _mockDbConnector.Setup(x => x.GetDataBaseReference(databaseId)).Returns((DataBaseRef?)null);
+
+            // Act
+            await _controller.GetTableMetadataById(databaseId, tableId, null);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
+        public async Task GetTableMetadataById_TableNotFound_LogsAuditEvent()
+        {
+            // Arrange
+            DataBaseRef database = DataBaseRef.Create("exampledb");
+            string tableId = "nonexistenttable";
+
+            _mockDbConnector.Setup(x => x.GetDataBaseReference(database.Id)).Returns(database);
+            _mockDbConnector.Setup(x => x.GetFileReferenceCachedAsync(tableId, database, CancellationToken.None)).ReturnsAsync((PxFileRef?)null);
+
+            // Act
+            await _controller.GetTableMetadataById(database.Id, tableId, null);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
         public async Task GetMetadataById_FileExists_ReturnsJsonStat2()
         {
             // Arrange
@@ -391,6 +424,59 @@ namespace PxApi.UnitTests.ControllerTests
                 Assert.That(resultMeta.Dimension, Has.Count.EqualTo(4));
                 Assert.That(resultMeta.Size, Has.Count.EqualTo(4));
             };
+        }
+
+        [Test]
+        public async Task HeadMetadataAsync_DatabaseNotFound_LogsAuditEvent()
+        {
+            // Arrange
+            string databaseId = "nonexistentdb";
+            string tableId = "table1";
+
+            _mockDbConnector.Setup(x => x.GetDataBaseReference(databaseId)).Returns((DataBaseRef?)null);
+
+            // Act
+            await _controller.HeadMetadataAsync(databaseId, tableId, null);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
+        public async Task HeadMetadataAsync_TableNotFound_LogsAuditEvent()
+        {
+            // Arrange
+            DataBaseRef database = DataBaseRef.Create("exampledb");
+            string tableId = "nonexistenttable";
+
+            _mockDbConnector.Setup(x => x.GetDataBaseReference(database.Id)).Returns(database);
+            _mockDbConnector.Setup(x => x.GetFileReferenceCachedAsync(tableId, database, CancellationToken.None)).ReturnsAsync((PxFileRef?)null);
+
+            // Act
+            await _controller.HeadMetadataAsync(database.Id, tableId, null);
+
+            // Assert
+            _mockAuditLogService.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
+        public async Task HeadMetadataAsync_UnexpectedError_ReturnsInternalServerError()
+        {
+            // Arrange
+            DataBaseRef database = DataBaseRef.Create("exampledb");
+            PxFileRef file = PxFileRef.ValidateAndCreate("filename", database, ["statisticalProgram"]);
+
+            _mockDbConnector.Setup(x => x.GetDataBaseReference(database.Id)).Returns(database);
+            _mockDbConnector.Setup(x => x.GetFileReferenceCachedAsync(file.Id, database, CancellationToken.None)).ReturnsAsync(file);
+            _mockDbConnector.Setup(x => x.GetMetadataCachedAsync(file, CancellationToken.None)).ThrowsAsync(new InvalidOperationException("Unexpected error"));
+
+            // Act
+            IActionResult result = await _controller.HeadMetadataAsync(database.Id, file.Id, null);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<StatusCodeResult>());
+            StatusCodeResult? statusResult = result as StatusCodeResult;
+            Assert.That(statusResult?.StatusCode, Is.EqualTo(500));
         }
 
         [Test]

--- a/PxApi.UnitTests/ControllerTests/TablesControllerTests.cs
+++ b/PxApi.UnitTests/ControllerTests/TablesControllerTests.cs
@@ -106,6 +106,24 @@ namespace PxApi.UnitTests.ControllerTests
         }
 
         [Test]
+        public async Task GetTablesAsync_DatabaseNotFound_LogsAuditEvent()
+        {
+            // Arrange
+            string dbId = "nonexistentdb";
+            string lang = "en";
+            int page = 1;
+            int pageSize = 50;
+
+            _cachedDbConnector.Setup(ds => ds.GetDataBaseReference(dbId)).Returns((DataBaseRef?)null);
+
+            // Act
+            await _controller.GetTablesAsync(dbId, lang, page, pageSize);
+
+            // Assert
+            _mockAuditLogger.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
         public async Task GetTablesAsync_TwoTables_ReturnsExpectedMetadata()
         {
             // Arrange
@@ -396,6 +414,23 @@ namespace PxApi.UnitTests.ControllerTests
         #region HeadTablesAsync Tests
 
         [Test]
+        public void HeadTablesAsync_DatabaseNotFound_LogsAuditEvent()
+        {
+            // Arrange
+            string database = "nonexistentdb";
+            int page = 1;
+            int pageSize = 50;
+
+            _cachedDbConnector.Setup(ds => ds.GetDataBaseReference(database)).Returns((DataBaseRef?)null);
+
+            // Act
+            _controller.HeadTablesAsync(database, page, pageSize);
+
+            // Assert
+            _mockAuditLogger.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
+
+        [Test]
         public void HeadTablesAsync_ValidParameters_ReturnsOk()
         {
             // Arrange
@@ -478,6 +513,22 @@ namespace PxApi.UnitTests.ControllerTests
         #endregion
 
         #region OptionsTables Tests
+
+        [Test]
+        public void OptionsTables_DatabaseNotFound_ReturnsNotFoundAndLogsAudit()
+        {
+            // Arrange
+            string database = "nonexistentdb";
+
+            _cachedDbConnector.Setup(ds => ds.GetDataBaseReference(database)).Returns((DataBaseRef?)null);
+
+            // Act
+            IActionResult result = _controller.OptionsTables(database);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+            _mockAuditLogger.Verify(x => x.LogAuditEvent(), Times.Once);
+        }
 
         [Test]
         public void OptionsTables_AnyDatabase_ReturnsOkWithAllowHeader()

--- a/PxApi/Controllers/DataController.cs
+++ b/PxApi/Controllers/DataController.cs
@@ -194,8 +194,8 @@ namespace PxApi.Controllers
                         }))
                         {
                             auditLogService.LogAuditEvent();
+                            return NotFound();
                         }
-                        return NotFound();
                     }
 
                     PxFileRef? fileRef = await dataSource.GetFileReferenceCachedAsync(table, dbRef.Value);
@@ -208,8 +208,8 @@ namespace PxApi.Controllers
                         }))
                         {
                             auditLogService.LogAuditEvent();
+                            return NotFound();
                         }
-                        return NotFound();
                     }
 
                     using (logger.BeginScope(new Dictionary<string, object>()
@@ -218,10 +218,10 @@ namespace PxApi.Controllers
                         { LoggerConsts.PX_FILE, fileRef.Value.Id }
                     }))
                     {
+                        auditLogService.LogAuditEvent();
                         IReadOnlyMatrixMetadata meta = await dataSource.GetMetadataCachedAsync(fileRef.Value);
                         string actualLang = lang ?? meta.DefaultLanguage;
                         if (!meta.AvailableLanguages.Contains(actualLang)) return BadRequest();
-                        auditLogService.LogAuditEvent();
                         return Ok();
                     }
                 }
@@ -254,10 +254,10 @@ namespace PxApi.Controllers
                 }))
                 {
                     auditLogService.LogAuditEvent();
+                    const string message = "The requested database was not found.";
+                    logger.LogDebug(message);
+                    return NotFound(message);
                 }
-                const string message = "The requested database was not found.";
-                logger.LogDebug(message);
-                return NotFound(message);
             }
             PxFileRef? fileRef = await dataSource.GetFileReferenceCachedAsync(table, dbRef.Value);
             if (fileRef is null)
@@ -269,10 +269,10 @@ namespace PxApi.Controllers
                 }))
                 {
                     auditLogService.LogAuditEvent();
+                    const string message = "The requested Px table was not found.";
+                    logger.LogDebug(message);
+                    return NotFound(message);
                 }
-                const string message = "The requested Px table was not found.";
-                logger.LogDebug(message);
-                return NotFound(message);
             }
 
             using (logger.BeginScope(new Dictionary<string, object>()

--- a/PxApi/Controllers/DataController.cs
+++ b/PxApi/Controllers/DataController.cs
@@ -82,7 +82,6 @@ namespace PxApi.Controllers
                     return BadRequest(HttpConsts.BAD_REQUEST_PARAMS);
                 }
 
-                auditLogService.LogAuditEvent();
                 return await GenerateResponse(database, table, lang, query);
             }
         }
@@ -128,7 +127,6 @@ namespace PxApi.Controllers
                 { LoggerConsts.ACTION, nameof(PostDataAsync) }
             }))
             {
-                auditLogService.LogAuditEvent();
                 return await GenerateResponse(database, table, lang, query);
             }
         }
@@ -187,10 +185,32 @@ namespace PxApi.Controllers
                 try
                 {
                     DataBaseRef? dbRef = dataSource.GetDataBaseReference(database);
-                    if (dbRef is null) return NotFound();
+                    if (dbRef is null)
+                    {
+                        using (logger.BeginScope(new Dictionary<string, object>()
+                        {
+                            { LoggerConsts.DB_ID, LoggerConsts.NOT_FOUND_PLACEHOLDER },
+                            { LoggerConsts.PX_FILE, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                        }))
+                        {
+                            auditLogService.LogAuditEvent();
+                        }
+                        return NotFound();
+                    }
 
                     PxFileRef? fileRef = await dataSource.GetFileReferenceCachedAsync(table, dbRef.Value);
-                    if (fileRef is null) return NotFound();
+                    if (fileRef is null)
+                    {
+                        using (logger.BeginScope(new Dictionary<string, object>()
+                        {
+                            { LoggerConsts.DB_ID, dbRef.Value.Id },
+                            { LoggerConsts.PX_FILE, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                        }))
+                        {
+                            auditLogService.LogAuditEvent();
+                        }
+                        return NotFound();
+                    }
 
                     using (logger.BeginScope(new Dictionary<string, object>()
                     {
@@ -227,6 +247,14 @@ namespace PxApi.Controllers
             DataBaseRef? dbRef = dataSource.GetDataBaseReference(database);
             if (dbRef is null)
             {
+                using (logger.BeginScope(new Dictionary<string, object>()
+                {
+                    { LoggerConsts.DB_ID, LoggerConsts.NOT_FOUND_PLACEHOLDER },
+                    { LoggerConsts.PX_FILE, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                }))
+                {
+                    auditLogService.LogAuditEvent();
+                }
                 const string message = "The requested database was not found.";
                 logger.LogDebug(message);
                 return NotFound(message);
@@ -234,6 +262,14 @@ namespace PxApi.Controllers
             PxFileRef? fileRef = await dataSource.GetFileReferenceCachedAsync(table, dbRef.Value);
             if (fileRef is null)
             {
+                using (logger.BeginScope(new Dictionary<string, object>()
+                {
+                    { LoggerConsts.DB_ID, dbRef.Value.Id },
+                    { LoggerConsts.PX_FILE, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                }))
+                {
+                    auditLogService.LogAuditEvent();
+                }
                 const string message = "The requested Px table was not found.";
                 logger.LogDebug(message);
                 return NotFound(message);
@@ -245,6 +281,7 @@ namespace PxApi.Controllers
                 { LoggerConsts.PX_FILE, fileRef.Value.Id }
             }))
             {
+                auditLogService.LogAuditEvent();
                 try
                 {
                     IReadOnlyMatrixMetadata meta = await dataSource.GetMetadataCachedAsync(fileRef.Value);

--- a/PxApi/Controllers/MetadataController.cs
+++ b/PxApi/Controllers/MetadataController.cs
@@ -51,10 +51,32 @@ namespace PxApi.Controllers
                 try
                 {
                     DataBaseRef? dbRef = cachedConnector.GetDataBaseReference(database);
-                    if (dbRef is null) return NotFound("Database not found.");
+                    if (dbRef is null)
+                    {
+                        using (logger.BeginScope(new Dictionary<string, object>
+                        {
+                            { LoggerConsts.DB_ID, LoggerConsts.NOT_FOUND_PLACEHOLDER },
+                            { LoggerConsts.PX_FILE, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                        }))
+                        {
+                            auditLogService.LogAuditEvent();
+                        }
+                        return NotFound("Database not found.");
+                    }
 
                     PxFileRef? fileRef = await cachedConnector.GetFileReferenceCachedAsync(table, dbRef.Value);
-                    if (fileRef is null) return NotFound("Table not found.");
+                    if (fileRef is null)
+                    {
+                        using (logger.BeginScope(new Dictionary<string, object>
+                        {
+                            { LoggerConsts.DB_ID, dbRef.Value.Id },
+                            { LoggerConsts.PX_FILE, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                        }))
+                        {
+                            auditLogService.LogAuditEvent();
+                        }
+                        return NotFound("Table not found.");
+                    }
 
                     using (logger.BeginScope(new Dictionary<string, object>
                         {
@@ -62,6 +84,7 @@ namespace PxApi.Controllers
                             { LoggerConsts.PX_FILE, fileRef.Value.Id }
                         }))
                     {
+                        auditLogService.LogAuditEvent();
                         IReadOnlyMatrixMetadata meta = await cachedConnector.GetMetadataCachedAsync(fileRef.Value);
 
                         string resolvedLang = lang ?? meta.DefaultLanguage;
@@ -72,7 +95,6 @@ namespace PxApi.Controllers
 
                         IReadOnlyList<TableGroup> groupings = await cachedConnector.GetGroupingsCachedAsync(fileRef.Value);
                         JsonStat2 jsonStat2 = JsonStat2Builder.BuildJsonStat2(meta, groupings, resolvedLang);
-                        auditLogService.LogAuditEvent();
                         return Ok(jsonStat2);
                     }
                 }
@@ -115,10 +137,32 @@ namespace PxApi.Controllers
                 try
                 {
                     DataBaseRef? dbRef = cachedConnector.GetDataBaseReference(database);
-                    if (dbRef is null) return NotFound();
+                    if (dbRef is null)
+                    {
+                        using (logger.BeginScope(new Dictionary<string, object>
+                        {
+                            { LoggerConsts.DB_ID, LoggerConsts.NOT_FOUND_PLACEHOLDER },
+                            { LoggerConsts.PX_FILE, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                        }))
+                        {
+                            auditLogService.LogAuditEvent();
+                        }
+                        return NotFound();
+                    }
 
                     PxFileRef? fileRef = await cachedConnector.GetFileReferenceCachedAsync(table, dbRef.Value);
-                    if (fileRef is null) return NotFound();
+                    if (fileRef is null)
+                    {
+                        using (logger.BeginScope(new Dictionary<string, object>
+                        {
+                            { LoggerConsts.DB_ID, dbRef.Value.Id },
+                            { LoggerConsts.PX_FILE, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                        }))
+                        {
+                            auditLogService.LogAuditEvent();
+                        }
+                        return NotFound();
+                    }
 
                     using (logger.BeginScope(new Dictionary<string, object>
                         {
@@ -126,10 +170,10 @@ namespace PxApi.Controllers
                             { LoggerConsts.PX_FILE, fileRef.Value.Id }
                         }))
                     {
+                        auditLogService.LogAuditEvent();
                         IReadOnlyMatrixMetadata meta = await cachedConnector.GetMetadataCachedAsync(fileRef.Value);
                         string resolvedLang = lang ?? meta.DefaultLanguage;
                         if (!meta.AvailableLanguages.Contains(resolvedLang)) return BadRequest();
-                        auditLogService.LogAuditEvent();
                         return Ok();
                     }
                 }
@@ -154,9 +198,16 @@ namespace PxApi.Controllers
         [ProducesResponseType(500)]
         public IActionResult OptionsMetadata(string database, string table)
         {
-            Response.Headers.Allow = "GET,HEAD,OPTIONS";
-            auditLogService.LogAuditEvent();
-            return Ok();
+            using (logger.BeginScope(new Dictionary<string, object>
+            {
+                { LoggerConsts.CONTROLLER, nameof(MetadataController) },
+                { LoggerConsts.ACTION, nameof(OptionsMetadata) }
+            }))
+            {
+                Response.Headers.Allow = "GET,HEAD,OPTIONS";
+                auditLogService.LogAuditEvent();
+                return Ok();
+            }
         }
     }
 }

--- a/PxApi/Controllers/MetadataController.cs
+++ b/PxApi/Controllers/MetadataController.cs
@@ -60,8 +60,8 @@ namespace PxApi.Controllers
                         }))
                         {
                             auditLogService.LogAuditEvent();
+                            return NotFound("Database not found.");
                         }
-                        return NotFound("Database not found.");
                     }
 
                     PxFileRef? fileRef = await cachedConnector.GetFileReferenceCachedAsync(table, dbRef.Value);
@@ -74,8 +74,8 @@ namespace PxApi.Controllers
                         }))
                         {
                             auditLogService.LogAuditEvent();
+                            return NotFound("Table not found.");
                         }
-                        return NotFound("Table not found.");
                     }
 
                     using (logger.BeginScope(new Dictionary<string, object>
@@ -146,8 +146,8 @@ namespace PxApi.Controllers
                         }))
                         {
                             auditLogService.LogAuditEvent();
+                            return NotFound();
                         }
-                        return NotFound();
                     }
 
                     PxFileRef? fileRef = await cachedConnector.GetFileReferenceCachedAsync(table, dbRef.Value);
@@ -160,8 +160,8 @@ namespace PxApi.Controllers
                         }))
                         {
                             auditLogService.LogAuditEvent();
+                            return NotFound();
                         }
-                        return NotFound();
                     }
 
                     using (logger.BeginScope(new Dictionary<string, object>

--- a/PxApi/Controllers/TablesController.cs
+++ b/PxApi/Controllers/TablesController.cs
@@ -63,7 +63,19 @@ namespace PxApi.Controllers
             try
             {
                 DataBaseRef? dataBaseRef = cachedConnector.GetDataBaseReference(database);
-                if (dataBaseRef is null) return NotFound("Database not found.");
+                if (dataBaseRef is null)
+                {
+                    using (logger.BeginScope(new Dictionary<string, object>
+                    {
+                        { LoggerConsts.CONTROLLER, nameof(TablesController) },
+                        { LoggerConsts.ACTION, nameof(GetTablesAsync) },
+                        { LoggerConsts.DB_ID, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                    }))
+                    {
+                        auditLogger.LogAuditEvent();
+                    }
+                    return NotFound("Database not found.");
+                }
 
                 using (logger.BeginScope(new Dictionary<string, object>
                 {
@@ -140,7 +152,19 @@ namespace PxApi.Controllers
         {
             if (page < 1 || pageSize < 1 || pageSize > MAX_PAGE_SIZE) return BadRequest();
             DataBaseRef? dataBaseRef = cachedConnector.GetDataBaseReference(database);
-            if (dataBaseRef is null) return NotFound();
+            if (dataBaseRef is null)
+            {
+                using (logger.BeginScope(new Dictionary<string, object>
+                {
+                    { LoggerConsts.CONTROLLER, nameof(TablesController) },
+                    { LoggerConsts.ACTION, nameof(HeadTablesAsync) },
+                    { LoggerConsts.DB_ID, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                }))
+                {
+                    auditLogger.LogAuditEvent();
+                }
+                return NotFound();
+            }
 
             using (logger.BeginScope(new Dictionary<string, object>
                 {
@@ -172,7 +196,19 @@ namespace PxApi.Controllers
         public IActionResult OptionsTables(string database)
         {
             DataBaseRef? dataBaseRef = cachedConnector.GetDataBaseReference(database);
-            if (dataBaseRef is null) return NotFound("Database not found.");
+            if (dataBaseRef is null)
+            {
+                using (logger.BeginScope(new Dictionary<string, object>
+                {
+                    { LoggerConsts.CONTROLLER, nameof(TablesController) },
+                    { LoggerConsts.ACTION, nameof(OptionsTables) },
+                    { LoggerConsts.DB_ID, LoggerConsts.NOT_FOUND_PLACEHOLDER }
+                }))
+                {
+                    auditLogger.LogAuditEvent();
+                }
+                return NotFound("Database not found.");
+            }
 
             using (logger.BeginScope(new Dictionary<string, object>
                 {

--- a/PxApi/Controllers/TablesController.cs
+++ b/PxApi/Controllers/TablesController.cs
@@ -162,8 +162,8 @@ namespace PxApi.Controllers
                 }))
                 {
                     auditLogger.LogAuditEvent();
+                    return NotFound();
                 }
-                return NotFound();
             }
 
             using (logger.BeginScope(new Dictionary<string, object>

--- a/PxApi/PxApi.csproj
+++ b/PxApi/PxApi.csproj
@@ -5,7 +5,7 @@
    <Nullable>enable</Nullable>
    <ImplicitUsings>enable</ImplicitUsings>
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-   <Version>0.3.3</Version>
+   <Version>0.3.4</Version>
  </PropertyGroup>
 
  <ItemGroup>

--- a/PxApi/Utilities/LoggerConsts.cs
+++ b/PxApi/Utilities/LoggerConsts.cs
@@ -41,6 +41,10 @@ namespace PxApi.Utilities
         /// Used to identify a blob name in logging scopes.
         /// </summary>
         public const string BLOB_NAME = "BlobName";
+        /// <summary>
+        /// Placeholder value used in logging scopes when a requested resource was not found.
+        /// </summary>
+        public const string NOT_FOUND_PLACEHOLDER = "Not found";
 
     }
 }


### PR DESCRIPTION
Ensure all "not found" (404) responses in DataController, MetadataController, and TablesController are logged via the audit logging service, using a placeholder in the logging scope. Update LoggerConsts with a NOT_FOUND_PLACEHOLDER. Add and extend unit tests to verify audit logging occurs for missing database/table scenarios in GET, POST, HEAD, and OPTIONS endpoints. Remove redundant audit log calls and ensure consistent audit behavior across endpoints.