### PR TITLE
[Feature] Add headers to endpoint paths

### DIFF
--- a/PxApi.UnitTests/ControllerTests/DatabasesControllerTests.cs
+++ b/PxApi.UnitTests/ControllerTests/DatabasesControllerTests.cs
@@ -90,7 +90,7 @@ namespace PxApi.UnitTests.ControllerTests
             {
                 Assert.That(result, Is.InstanceOf<OkResult>());
                 Assert.That(_controller.Response.Headers.Allow, Is.EqualTo("GET,HEAD,OPTIONS"));
-            };
+            }
             _mockAuditLogger.Verify(x => x.LogAuditEvent(), Times.Once);
         }
 
@@ -139,7 +139,7 @@ namespace PxApi.UnitTests.ControllerTests
                 Assert.That(items!, Has.Count.EqualTo(1));
                 Assert.That(items![0].Name, Is.EqualTo("Nimi FI")); // Default language fi
                 Assert.That(items![0].AvailableLanguages, Is.EquivalentTo(new List<string> { "fi", "en" }));
-            };
+            }
             _mockCachedDataSource.Verify(x => x.GetDatabaseNameAsync(dbRef, string.Empty, CancellationToken.None), Times.Once);
             _mockCachedDataSource.Verify(x => x.GetFileListCachedAsync(dbRef, CancellationToken.None), Times.Once);
         }
@@ -184,7 +184,7 @@ namespace PxApi.UnitTests.ControllerTests
             {
                 Assert.That(items![0].Description, Is.Null);
                 Assert.That(items[0].Name, Is.EqualTo("Namn SV"));
-            };
+            }
         }
 
         [Test]
@@ -259,7 +259,7 @@ namespace PxApi.UnitTests.ControllerTests
                 Assert.That(item1.Links, Has.Count.EqualTo(1));
                 Assert.That(item1.Links[0].Rel, Is.EqualTo("describedby"));
                 Assert.That(item1.Links[0].Method, Is.EqualTo("GET"));
-                string expectedHref1 = AppSettings.Active.RootUrl.ToString().TrimEnd('/') + "/tables/db1?lang=en";
+                string expectedHref1 = AppSettings.Active.RootUrl.ToString().TrimEnd('/') + "/meta/databases/db1/tables?lang=en";
                 Assert.That(item1.Links[0].Href, Is.EqualTo(expectedHref1));
                 // db2
                 DataBaseListingItem item2 = items!.First(i => i.ID == "db2");
@@ -267,9 +267,9 @@ namespace PxApi.UnitTests.ControllerTests
                 Assert.That(item2.Description, Is.EqualTo("Description EN2"));
                 Assert.That(item2.TableCount, Is.EqualTo(1));
                 Assert.That(item2.AvailableLanguages, Is.EquivalentTo(new List<string> { "fi", "en" }));
-                string expectedHref2 = AppSettings.Active.RootUrl.ToString().TrimEnd('/') + "/tables/db2?lang=en";
+                string expectedHref2 = AppSettings.Active.RootUrl.ToString().TrimEnd('/') + "/meta/databases/db2/tables?lang=en";
                 Assert.That(item2.Links[0].Href, Is.EqualTo(expectedHref2));
-            };
+            }
             _mockCachedDataSource.Verify(x => x.GetDatabaseNameAsync(dbRef1, string.Empty, CancellationToken.None), Times.Once);
             _mockCachedDataSource.Verify(x => x.GetDatabaseNameAsync(dbRef2, string.Empty, CancellationToken.None), Times.Once);
             _mockCachedDataSource.Verify(x => x.GetFileListCachedAsync(dbRef1, CancellationToken.None), Times.Once);
@@ -297,7 +297,7 @@ namespace PxApi.UnitTests.ControllerTests
             {
                 Assert.That(result, Is.InstanceOf<OkResult>());
                 Assert.That(_controller.Response.Headers.Allow, Is.EqualTo("GET,HEAD,OPTIONS"));
-            };
+            }
         }
     }
 }

--- a/PxApi.UnitTests/ControllerTests/TablesControllerTests.cs
+++ b/PxApi.UnitTests/ControllerTests/TablesControllerTests.cs
@@ -18,6 +18,10 @@ namespace PxApi.UnitTests.ControllerTests
     [TestFixture]
     public class TablesControllerTests
     {
+        private const string NonExistentDb = "nonexistentdb";
+        private const string StatisticalProgram = "statisticalProgram";
+        private const string File1Name = "file1";
+        private const string Table1Name = "table1";
         private Mock<ICachedDataSource> _cachedDbConnector;
         private Mock<ILogger<TablesController>> _mockLogger;
         private Mock<IAuditLogService> _mockAuditLogger; // Added mock for audit service
@@ -109,7 +113,7 @@ namespace PxApi.UnitTests.ControllerTests
         public async Task GetTablesAsync_DatabaseNotFound_LogsAuditEvent()
         {
             // Arrange
-            string dbId = "nonexistentdb";
+            string dbId = NonExistentDb;
             string lang = "en";
             int page = 1;
             int pageSize = 50;
@@ -131,11 +135,11 @@ namespace PxApi.UnitTests.ControllerTests
             string lang = "en";
             int page = 1;
             int pageSize = 50;
-            PxFileRef file1 = PxFileRef.ValidateAndCreate("file1", db, ["statisticalProgram"]);
-            PxFileRef file2 = PxFileRef.ValidateAndCreate("file2", db, ["statisticalProgram"]);
+            PxFileRef file1 = PxFileRef.ValidateAndCreate(File1Name, db, [StatisticalProgram]);
+            PxFileRef file2 = PxFileRef.ValidateAndCreate("file2", db, [StatisticalProgram]);
             ImmutableSortedDictionary<string, PxFileRef> tableList = ImmutableSortedDictionary.CreateRange(new Dictionary<string, PxFileRef>
             {
-                { "file1", file1 },
+                { File1Name, file1 },
                 { "file2", file2 }
             });
             MatrixMetadata meta1 = TestMockMetaBuilder.GetMockMetadata();
@@ -160,13 +164,13 @@ namespace PxApi.UnitTests.ControllerTests
             {
                 Assert.That(pagedTableList.Tables[0].ID, Is.EqualTo("table-tableid"));
                 Assert.That(pagedTableList.Tables[0].Title, Is.EqualTo("table-description.en"));
-                Assert.That(pagedTableList.Tables[0].Name, Is.EqualTo("file1"));
+                Assert.That(pagedTableList.Tables[0].Name, Is.EqualTo(File1Name));
                 Assert.That(pagedTableList.Tables[0].LastUpdated, Is.EqualTo(meta1.GetContentDimension().Values.Map(v => v.LastUpdated).Max()));
                 Assert.That(pagedTableList.Tables[0].Links, Has.Count.EqualTo(1));
                 Assert.That(pagedTableList.Tables[0].Links[0].Rel, Is.EqualTo("describedby"));
-                Assert.That(pagedTableList.Tables[0].Links[0].Href, Is.EqualTo("https://testurl.fi/meta/exampledb/file1?lang=en"));
+                Assert.That(pagedTableList.Tables[0].Links[0].Href, Is.EqualTo("https://testurl.fi/meta/databases/exampledb/tables/file1?lang=en"));
                 Assert.That(pagedTableList.Tables[0].Links[0].Method, Is.EqualTo("GET"));
-            };
+            }
         }
 
         [Test]
@@ -195,7 +199,7 @@ namespace PxApi.UnitTests.ControllerTests
             int pageSize = 200;
             DataBaseRef db = DataBaseRef.Create(dbId);
             ImmutableSortedDictionary<string, PxFileRef> tableList = ImmutableSortedDictionary<string, PxFileRef>.Empty;
-            
+
             _cachedDbConnector.Setup(ds => ds.GetDataBaseReference(dbId)).Returns(db);
             _cachedDbConnector.Setup(ds => ds.GetFileListCachedAsync(db, CancellationToken.None)).ReturnsAsync(tableList);
 
@@ -215,11 +219,11 @@ namespace PxApi.UnitTests.ControllerTests
         public async Task GetTablesAsync_DatabaseNotFound_ReturnsNotFound()
         {
             // Arrange
-            string dbId = "nonexistentdb";
+            string dbId = NonExistentDb;
             string lang = "en";
             int page = 1;
             int pageSize = 50;
-            
+
             _cachedDbConnector.Setup(ds => ds.GetDataBaseReference(dbId)).Returns((DataBaseRef?)null);
 
             // Act
@@ -238,7 +242,7 @@ namespace PxApi.UnitTests.ControllerTests
             string lang = "en";
             int page = 1;
             int pageSize = 50;
-            
+
             _cachedDbConnector.Setup(ds => ds.GetDataBaseReference(dbId)).Returns(db);
             _cachedDbConnector.Setup(ds => ds.GetFileListCachedAsync(db, CancellationToken.None)).ThrowsAsync(new DirectoryNotFoundException("Directory not found"));
 
@@ -257,24 +261,24 @@ namespace PxApi.UnitTests.ControllerTests
             DataBaseRef db = DataBaseRef.Create(dbId);
             string lang = "en";
             int pageSize = 3;
-            
+
             List<PxFileRef> files =
             [
-                PxFileRef.ValidateAndCreate("file1", db, ["statisticalProgram"]),
-                PxFileRef.ValidateAndCreate("file2", db, ["statisticalProgram"]),
-                PxFileRef.ValidateAndCreate("file3", db, ["statisticalProgram"]),
-                PxFileRef.ValidateAndCreate("file4", db, ["statisticalProgram"]),
-                PxFileRef.ValidateAndCreate("file5", db, ["statisticalProgram"]),
-                PxFileRef.ValidateAndCreate("file6", db, ["statisticalProgram"]),
-                PxFileRef.ValidateAndCreate("file7", db, ["statisticalProgram"]),
+                PxFileRef.ValidateAndCreate(File1Name, db, [StatisticalProgram]),
+                PxFileRef.ValidateAndCreate("file2", db, [StatisticalProgram]),
+                PxFileRef.ValidateAndCreate("file3", db, [StatisticalProgram]),
+                PxFileRef.ValidateAndCreate("file4", db, [StatisticalProgram]),
+                PxFileRef.ValidateAndCreate("file5", db, [StatisticalProgram]),
+                PxFileRef.ValidateAndCreate("file6", db, [StatisticalProgram]),
+                PxFileRef.ValidateAndCreate("file7", db, [StatisticalProgram]),
             ];
-            
+
             ImmutableSortedDictionary<string, PxFileRef> tableList = ImmutableSortedDictionary.CreateRange(
                 files.ToDictionary(f => f.Id));
-            
+
             _cachedDbConnector.Setup(ds => ds.GetDataBaseReference(dbId)).Returns(db);
             _cachedDbConnector.Setup(ds => ds.GetFileListCachedAsync(db, CancellationToken.None)).ReturnsAsync(tableList);
-            
+
             foreach (PxFileRef file in files)
             {
                 _cachedDbConnector.Setup(ds => ds.GetMetadataCachedAsync(file, CancellationToken.None)).ReturnsAsync(TestMockMetaBuilder.GetMockMetadata());
@@ -292,7 +296,7 @@ namespace PxApi.UnitTests.ControllerTests
                 PagedTableList? pagedTableList = okResult.Value as PagedTableList;
                 Assert.That(pagedTableList, Is.Not.Null);
 
-                if(page == 3) Assert.That(pagedTableList.Tables, Has.Count.EqualTo(1));
+                if (page == 3) Assert.That(pagedTableList.Tables, Has.Count.EqualTo(1));
                 else Assert.That(pagedTableList.Tables, Has.Count.EqualTo(3));
 
                 using (Assert.EnterMultipleScope())
@@ -301,7 +305,7 @@ namespace PxApi.UnitTests.ControllerTests
                     {
                         Assert.That(pagedTableList.Tables[i].Name, Is.EqualTo(files[tableIndex++].Id));
                     }
-                };
+                }
 
                 Assert.That(pagedTableList.PagingInfo.CurrentPage, Is.EqualTo(page));
             }
@@ -318,8 +322,8 @@ namespace PxApi.UnitTests.ControllerTests
             string lang = "en";
             int page = 1;
             int pageSize = 50;
-            
-            PxFileRef file = PxFileRef.ValidateAndCreate("table1", db, ["statisticalProgram"]);
+
+            PxFileRef file = PxFileRef.ValidateAndCreate(Table1Name, db, [StatisticalProgram]);
             ImmutableSortedDictionary<string, PxFileRef> tableList = ImmutableSortedDictionary.CreateRange(
                 new Dictionary<string, PxFileRef> { { file.Id, file } });
 
@@ -344,11 +348,11 @@ namespace PxApi.UnitTests.ControllerTests
                 else
                 {
                     Assert.That(pageTableList.Tables, Has.Count.EqualTo(1));
-                    Assert.That(pageTableList.Tables[0].ID, Is.EqualTo("table1"));
-                    Assert.That(pageTableList.Tables[0].Name, Is.EqualTo("table1"));
+                    Assert.That(pageTableList.Tables[0].ID, Is.EqualTo(Table1Name));
+                    Assert.That(pageTableList.Tables[0].Name, Is.EqualTo(Table1Name));
                     Assert.That(pageTableList.Tables[0].Status, Is.EqualTo(TableStatus.Error));
                 }
-            };
+            }
         }
 
         [Test]
@@ -360,15 +364,15 @@ namespace PxApi.UnitTests.ControllerTests
             string lang = "en";
             int page = 1;
             int pageSize = 50;
-            
-            PxFileRef file = PxFileRef.ValidateAndCreate("table1", db, ["statisticalProgram"]);
+
+            PxFileRef file = PxFileRef.ValidateAndCreate(Table1Name, db, [StatisticalProgram]);
             ImmutableSortedDictionary<string, PxFileRef> tableList = ImmutableSortedDictionary.CreateRange(
                 new Dictionary<string, PxFileRef> { { file.Id, file } });
 
             // Create metadata with only non-content dimensions (time dimension and regular dimensions)
             // This will cause TryGetContentDimension to return false
             MatrixMetadata metaWithoutContent = TestMockMetaBuilder.GetMockMetadata([
-                Px.Utils.Models.Metadata.Enums.DimensionType.Ordinal, 
+                Px.Utils.Models.Metadata.Enums.DimensionType.Ordinal,
                 Px.Utils.Models.Metadata.Enums.DimensionType.Nominal
             ]);
 
@@ -404,11 +408,11 @@ namespace PxApi.UnitTests.ControllerTests
                 {
                     Assert.That(pageTableList.Tables, Has.Count.EqualTo(1));
                     Assert.That(pageTableList.Tables[0].ID, Is.EqualTo("table-tableid"));
-                    Assert.That(pageTableList.Tables[0].Name, Is.EqualTo("table1"));
+                    Assert.That(pageTableList.Tables[0].Name, Is.EqualTo(Table1Name));
                     Assert.That(pageTableList.Tables[0].Status, Is.EqualTo(TableStatus.Error));
                     Assert.That(pageTableList.Tables[0].LastUpdated, Is.EqualTo(DateTime.MinValue));
                 }
-            };
+            }
         }
 
         #region HeadTablesAsync Tests
@@ -417,7 +421,7 @@ namespace PxApi.UnitTests.ControllerTests
         public void HeadTablesAsync_DatabaseNotFound_LogsAuditEvent()
         {
             // Arrange
-            string database = "nonexistentdb";
+            string database = NonExistentDb;
             int page = 1;
             int pageSize = 50;
 
@@ -497,7 +501,7 @@ namespace PxApi.UnitTests.ControllerTests
         public void HeadTablesAsync_DatabaseNotFound_ReturnsNotFound()
         {
             // Arrange
-            string database = "nonexistentdb";
+            string database = NonExistentDb;
             int page = 1;
             int pageSize = 50;
 
@@ -518,7 +522,7 @@ namespace PxApi.UnitTests.ControllerTests
         public void OptionsTables_DatabaseNotFound_ReturnsNotFoundAndLogsAudit()
         {
             // Arrange
-            string database = "nonexistentdb";
+            string database = NonExistentDb;
 
             _cachedDbConnector.Setup(ds => ds.GetDataBaseReference(database)).Returns((DataBaseRef?)null);
 
@@ -546,7 +550,7 @@ namespace PxApi.UnitTests.ControllerTests
             {
                 Assert.That(result, Is.InstanceOf<OkResult>());
                 Assert.That(_controller.Response.Headers.Allow.ToString(), Is.EqualTo("GET,HEAD,OPTIONS"));
-            };
+            }
         }
 
         #endregion

--- a/PxApi.UnitTests/OpenApi/DocumentFilters/DataControllerGetEndpointDocumentFilterTests.cs
+++ b/PxApi.UnitTests/OpenApi/DocumentFilters/DataControllerGetEndpointDocumentFilterTests.cs
@@ -9,6 +9,9 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
     [TestFixture]
     public class DataControllerGetEndpointDocumentFilterTests
     {
+        private const string ApplicationJson = "application/json";
+        private const string TextCsv = "text/csv";
+
         private static DocumentFilterContext CreateEmptyContext()
         {
             ISchemaGenerator schemaGenerator = Mock.Of<ISchemaGenerator>();
@@ -34,32 +37,32 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType(),
-                            ["text/csv"] = new OpenApiMediaType { Schema = new OpenApiSchema() }
+                            [ApplicationJson] = new OpenApiMediaType(),
+                            [TextCsv] = new OpenApiMediaType { Schema = new OpenApiSchema() }
                         }
                     },
                     ["400"] = new OpenApiResponse
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType(),
-                            ["text/csv"] = new OpenApiMediaType()
+                            [ApplicationJson] = new OpenApiMediaType(),
+                            [TextCsv] = new OpenApiMediaType()
                         }
                     },
                     ["406"] = new OpenApiResponse
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType(),
-                            ["text/csv"] = new OpenApiMediaType()
+                            [ApplicationJson] = new OpenApiMediaType(),
+                            [TextCsv] = new OpenApiMediaType()
                         }
                     },
                     ["500"] = new OpenApiResponse
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType(),
-                            ["text/csv"] = new OpenApiMediaType()
+                            [ApplicationJson] = new OpenApiMediaType(),
+                            [TextCsv] = new OpenApiMediaType()
                         }
                     }
                 }
@@ -77,7 +80,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             {
                 Paths = new OpenApiPaths
                 {
-                    ["/data/{database}/{table}"] = pathItem
+                    ["/data/databases/{database}/tables/{table}"] = pathItem
                 }
             };
 
@@ -103,7 +106,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
 
             Assert.That(operation.Responses.ContainsKey("200"), Is.True);
             OpenApiResponse response200 = (OpenApiResponse)operation.Responses["200"];
-            OpenApiMediaType jsonMediaType = response200.Content!["application/json"];
+            OpenApiMediaType jsonMediaType = response200.Content![ApplicationJson];
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(jsonMediaType.Schema, Is.Not.Null);
@@ -114,7 +117,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
                 Assert.That(response200.Description, Does.Contain("JSON-stat"));
             }
 
-            OpenApiMediaType csvMediaType = response200.Content["text/csv"];
+            OpenApiMediaType csvMediaType = response200.Content[TextCsv];
             OpenApiSchema csvSchema = (OpenApiSchema)csvMediaType.Schema!;
             Assert.That(csvSchema!.Description, Does.Contain("CSV dataset"));
 
@@ -122,7 +125,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(response400.Content!.ContainsKey("text/csv"), Is.False);
-                Assert.That(response400.Content["application/json"], Is.Not.Null);
+                Assert.That(response400.Content[ApplicationJson], Is.Not.Null);
             }
 
             OpenApiResponse response406 = (OpenApiResponse)operation.Responses["406"];
@@ -132,7 +135,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(response500.Content!.ContainsKey("text/csv"), Is.False);
-                Assert.That(response500.Content["application/json"], Is.Not.Null);
+                Assert.That(response500.Content[ApplicationJson], Is.Not.Null);
             }
         }
 
@@ -142,14 +145,14 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             // Arrange
             OpenApiOperation operation = new()
             {
-                Parameters = [ new OpenApiParameter { Name = "filters" } ],
+                Parameters = [new OpenApiParameter { Name = "filters" }],
                 Responses = new OpenApiResponses
                 {
                     ["200"] = new OpenApiResponse
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType()
+                            [ApplicationJson] = new OpenApiMediaType()
                         }
                     }
                 }
@@ -178,7 +181,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             filter.Apply(document, context);
 
             // Assert (unchanged: description still null, example not set because logic not run)
-            OpenApiMediaType jsonMediaType = operation.Responses["200"].Content!["application/json"];
+            OpenApiMediaType jsonMediaType = operation.Responses["200"].Content![ApplicationJson];
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(operation.Description, Is.Null);

--- a/PxApi.UnitTests/OpenApi/DocumentFilters/DataControllerPostEndpointDocumentFilterTests.cs
+++ b/PxApi.UnitTests/OpenApi/DocumentFilters/DataControllerPostEndpointDocumentFilterTests.cs
@@ -10,6 +10,9 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
     [TestFixture]
     public class DataControllerPostEndpointDocumentFilterTests
     {
+        private const string ApplicationJson = "application/json";
+        private const string TextCsv = "text/csv";
+
         private static DocumentFilterContext CreateEmptyContext()
         {
             ISchemaGenerator schemaGenerator = Mock.Of<ISchemaGenerator>();
@@ -25,12 +28,12 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             // Arrange
             OpenApiOperation operation = new()
             {
-                Parameters = [ new OpenApiParameter { Name = "lang" } ],
+                Parameters = [new OpenApiParameter { Name = "lang" }],
                 RequestBody = new OpenApiRequestBody
                 {
                     Content = new Dictionary<string, OpenApiMediaType>
                     {
-                        ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema() }
+                        [ApplicationJson] = new OpenApiMediaType { Schema = new OpenApiSchema() }
                     }
                 },
                 Responses = new OpenApiResponses
@@ -39,32 +42,32 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType(),
-                            ["text/csv"] = new OpenApiMediaType { Schema = new OpenApiSchema() }
+                            [ApplicationJson] = new OpenApiMediaType(),
+                            [TextCsv] = new OpenApiMediaType { Schema = new OpenApiSchema() }
                         }
                     },
                     ["400"] = new OpenApiResponse
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType(),
-                            ["text/csv"] = new OpenApiMediaType()
+                            [ApplicationJson] = new OpenApiMediaType(),
+                            [TextCsv] = new OpenApiMediaType()
                         }
                     },
                     ["406"] = new OpenApiResponse
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType(),
-                            ["text/csv"] = new OpenApiMediaType()
+                            [ApplicationJson] = new OpenApiMediaType(),
+                            [TextCsv] = new OpenApiMediaType()
                         }
                     },
                     ["500"] = new OpenApiResponse
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType(),
-                            ["text/csv"] = new OpenApiMediaType()
+                            [ApplicationJson] = new OpenApiMediaType(),
+                            [TextCsv] = new OpenApiMediaType()
                         }
                     }
                 }
@@ -81,7 +84,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             OpenApiSchema filterSchema = new();
             OpenApiDocument document = new()
             {
-                Paths = new OpenApiPaths { ["/data/{database}/{table}"] = pathItem },
+                Paths = new OpenApiPaths { ["/data/databases/{database}/tables/{table}"] = pathItem },
                 Components = new OpenApiComponents
                 {
                     Schemas = new Dictionary<string, IOpenApiSchema>
@@ -98,7 +101,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             filter.Apply(document, context);
 
             // Assert request body examples
-            OpenApiMediaType rbMediaType = operation.RequestBody.Content!["application/json"];
+            OpenApiMediaType rbMediaType = operation.RequestBody.Content![ApplicationJson];
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(rbMediaType.Examples, Is.Not.Null);
@@ -109,7 +112,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
 
             // Assert response
             OpenApiResponse response200 = (OpenApiResponse)operation.Responses["200"];
-            OpenApiMediaType jsonMediaType = response200.Content!["application/json"];
+            OpenApiMediaType jsonMediaType = response200.Content![ApplicationJson];
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(jsonMediaType.Schema, Is.Not.Null);
@@ -120,7 +123,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
                 Assert.That(response200.Description, Does.Contain("JSON-stat 2.0"));
             }
 
-            OpenApiMediaType csvMediaType = response200.Content["text/csv"];
+            OpenApiMediaType csvMediaType = response200.Content[TextCsv];
             OpenApiSchema csvSchema = (OpenApiSchema)csvMediaType.Schema!;
             Assert.That(csvSchema.Description, Does.Contain("CSV dataset"));
 
@@ -141,7 +144,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(response400.Content!.ContainsKey("text/csv"), Is.False);
-                Assert.That(response400.Content["application/json"], Is.Not.Null);
+                Assert.That(response400.Content[ApplicationJson], Is.Not.Null);
             }
 
             OpenApiResponse response406 = (OpenApiResponse)operation.Responses["406"];
@@ -151,7 +154,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(response500.Content!.ContainsKey("text/csv"), Is.False);
-                Assert.That(response500.Content["application/json"], Is.Not.Null);
+                Assert.That(response500.Content[ApplicationJson], Is.Not.Null);
             }
         }
 
@@ -165,7 +168,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
                 {
                     Content = new Dictionary<string, OpenApiMediaType>
                     {
-                        ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema() }
+                        [ApplicationJson] = new OpenApiMediaType { Schema = new OpenApiSchema() }
                     }
                 },
                 Responses = new OpenApiResponses
@@ -174,7 +177,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
                     {
                         Content = new Dictionary<string, OpenApiMediaType>
                         {
-                            ["application/json"] = new OpenApiMediaType()
+                            [ApplicationJson] = new OpenApiMediaType()
                         }
                     }
                 }
@@ -203,7 +206,7 @@ namespace PxApi.UnitTests.OpenApi.DocumentFilters
             filter.Apply(document, context);
 
             // Assert
-            OpenApiMediaType rbMediaType = operation.RequestBody.Content!["application/json"];
+            OpenApiMediaType rbMediaType = operation.RequestBody.Content![ApplicationJson];
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(rbMediaType.Examples, Is.Null.Or.Empty);

--- a/PxApi.UnitTests/OpenApi/Examples/DatabaseListingExampleTests.cs
+++ b/PxApi.UnitTests/OpenApi/Examples/DatabaseListingExampleTests.cs
@@ -9,12 +9,14 @@ namespace PxApi.UnitTests.OpenApi.Examples
     [TestFixture]
     public class DatabaseListingExampleTests
     {
+        private const string TestDatabaseId = "StatFin";
+
         [SetUp]
         public void Setup()
         {
             Dictionary<string, string?> configData = TestConfigFactory.Merge(
                 TestConfigFactory.Base(),
-                TestConfigFactory.MountedDb(0, "StatFin", "datasource/root/")
+                TestConfigFactory.MountedDb(0, TestDatabaseId, "datasource/root/")
             );
             IConfiguration configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(configData)
@@ -54,8 +56,8 @@ namespace PxApi.UnitTests.OpenApi.Examples
             // Assert
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(database["id"]?.ToString(), Is.EqualTo("StatFin"));
-                Assert.That(database["name"]?.ToString(), Is.EqualTo("StatFin"));
+                Assert.That(database["id"]?.ToString(), Is.EqualTo(TestDatabaseId));
+                Assert.That(database["name"]?.ToString(), Is.EqualTo(TestDatabaseId));
                 Assert.That(database["description"], Is.Null);
                 Assert.That(database["tableCount"]?.GetValue<int>(), Is.EqualTo(1526));
             }
@@ -112,7 +114,7 @@ namespace PxApi.UnitTests.OpenApi.Examples
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(link["href"]?.ToString(), Does.Contain("https://testurl.fi"));
-                Assert.That(link["href"]?.ToString(), Does.Contain("tables/StatFin"));
+                Assert.That(link["href"]?.ToString(), Does.Contain($"meta/databases/{TestDatabaseId}/tables"));
                 Assert.That(link["href"]?.ToString(), Does.Contain("lang=fi"));
                 Assert.That(link["rel"]?.ToString(), Is.EqualTo("describedby"));
                 Assert.That(link["method"]?.ToString(), Is.EqualTo("GET"));
@@ -126,7 +128,7 @@ namespace PxApi.UnitTests.OpenApi.Examples
             const string customRootUrl = "https://custom.example.com/api";
             Dictionary<string, string?> configData = TestConfigFactory.Merge(
                 TestConfigFactory.Base(),
-                TestConfigFactory.MountedDb(0, "StatFin", "datasource/root/"),
+                TestConfigFactory.MountedDb(0, TestDatabaseId, "datasource/root/"),
                 new Dictionary<string, string?>
                 {
                     ["RootUrl"] = customRootUrl

--- a/PxApi/Controllers/CacheController.cs
+++ b/PxApi/Controllers/CacheController.cs
@@ -19,7 +19,7 @@ namespace PxApi.Controllers
     /// <param name="logger">Logger for logging information, warnings and errors.</param>
     [ApiKeyAuth]
     [FeatureGate(nameof(CacheController))]
-    [Route("cache")]
+    [Route("cache/databases")]
     [ApiController]
     public class CacheController(ICachedDataSource cachedConnector, ILogger<CacheController> logger) : ControllerBase
     {
@@ -36,7 +36,7 @@ namespace PxApi.Controllers
         /// <response code="200">Cache for the specified PX file was successfully cleared.</response>
         /// <response code="404">If the database or PX file was not found.</response>
         /// <response code="500">If an error occurs while clearing the cache.</response>
-        [HttpDelete("{database}/{id}")]
+        [HttpDelete("{database}/tables/{id}")]
         [OperationId("clearTableCache")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), 200)]

--- a/PxApi/Controllers/DataController.cs
+++ b/PxApi/Controllers/DataController.cs
@@ -26,7 +26,7 @@ namespace PxApi.Controllers
     /// <param name="auditLogService">Audit logging service.</param>
     [ApiKeyAuth]
     [ApiController]
-    [Route("data")]
+    [Route("data/databases")]
     public class DataController(ICachedDataSource dataSource, ILogger<DataController> logger, IAuditLogService auditLogService) : ControllerBase
     {
         private static readonly string[] SupportedMediaTypes = ["application/json", "text/csv"];
@@ -47,7 +47,7 @@ namespace PxApi.Controllers
         /// <response code="415">Unsupported Content-Type header.</response>
         /// <response code="500">Unexpected internal server error.</response>
         /// <response code="503">The request is valid but the data is temporarily unavailable due to a database update.</response>
-        [HttpGet("{database}/{table}")]
+        [HttpGet("{database}/tables/{table}")]
         [OperationId("getData")]
         [Produces("application/json", "text/csv")]
         [ProducesResponseType(typeof(JsonStat2), 200, "application/json")]
@@ -102,7 +102,7 @@ namespace PxApi.Controllers
         /// <response code="415">Unsupported Content-Type for request body.</response>
         /// <response code="500">Unexpected internal server error.</response>
         /// <response code="503">The request is valid but the data is temporarily unavailable due to a database update.</response>
-        [HttpPost("{database}/{table}")]
+        [HttpPost("{database}/tables/{table}")]
         [OperationId("postData")]
         [Consumes("application/json")]
         [Produces("application/json", "text/csv")]
@@ -138,7 +138,7 @@ namespace PxApi.Controllers
         /// <param name="table">PX table identifier.</param>
         /// <response code="200">Returns allowed methods in the Allow response header.</response>
         /// <response code="500">Unexpected internal server error.</response>
-        [HttpOptions("{database}/{table}")]
+        [HttpOptions("{database}/tables/{table}")]
         [OperationId("optionsData")]
         [ProducesResponseType(200)]
         [ProducesResponseType(500)]
@@ -167,7 +167,7 @@ namespace PxApi.Controllers
         /// <response code="400">Invalid language requested.</response>
         /// <response code="404">Database or table not found.</response>
         /// <response code="500">Unexpected internal server error.</response>
-        [HttpHead("{database}/{table}")]
+        [HttpHead("{database}/tables/{table}")]
         [OperationId("headData")]
         [ProducesResponseType(200)]
         [ProducesResponseType(400)]

--- a/PxApi/Controllers/DatabasesController.cs
+++ b/PxApi/Controllers/DatabasesController.cs
@@ -12,19 +12,19 @@ using System.Collections.Immutable;
 namespace PxApi.Controllers
 {
     /// <summary>
-    /// Provides REST endpoints for discovering available PX databases. The base route for this controller is /databases.
+    /// Provides REST endpoints for discovering available PX databases. The base route for this controller is /meta/databases.
     /// </summary>
     /// <remarks>
     /// Current endpoints:
     /// <list type="bullet">
-    /// <item>GET /databases Lists all databases including localized name, optional description, table count and a link to list tables in the database.</item>
-    /// <item>HEAD /databases Returns only headers to indicate the database collection resource exists (useful for health checks / pre-flight).</item>
-    /// <item>OPTIONS /databases Returns allowed HTTP methods in the Allow response header.</item>
+    /// <item>GET /meta/databases Lists all databases including localized name, optional description, table count and a link to list tables in the database.</item>
+    /// <item>HEAD /meta/databases Returns only headers to indicate the database collection resource exists (useful for health checks / pre-flight).</item>
+    /// <item>OPTIONS /meta/databases Returns allowed HTTP methods in the Allow response header.</item>
     /// </list>
     /// Content negotiation: Only application/json is produced.
     /// </remarks>
     [ApiKeyAuth]
-    [Route("databases")]
+    [Route("meta/databases")]
     [ApiController]
     public class DatabasesController(ICachedDataSource dataSource, ILogger<DatabasesController> logger, IAuditLogService auditLogger) : ControllerBase
     {
@@ -39,7 +39,7 @@ namespace PxApi.Controllers
         [HttpGet]
         [OperationId("listDatabases")]
         [Produces("application/json")]
-        [ProducesResponseType(typeof(List<DataBaseListingItem>),200, "application/json")]
+        [ProducesResponseType(typeof(List<DataBaseListingItem>), 200, "application/json")]
         [ProducesResponseType(typeof(string), 400)]
         [ProducesResponseType(typeof(string), 500)]
         public async Task<ActionResult<List<DataBaseListingItem>>> GetDatabases([FromQuery] string? lang = null)
@@ -75,7 +75,7 @@ namespace PxApi.Controllers
                     Task<ImmutableSortedDictionary<string, PxFileRef>> filesTask = dataSource.GetFileListCachedAsync(dbRef);
                     ImmutableSortedDictionary<string, PxFileRef> files = await filesTask;
                     int tableCount = files.Count;
-                    Uri tablesUri = settings.RootUrl.AddRelativePath("tables", dbRef.Id).AddQueryParameters(("lang", actualLang));
+                    Uri tablesUri = settings.RootUrl.AddRelativePath("meta", "databases", dbRef.Id, "tables").AddQueryParameters(("lang", actualLang));
 
                     // Determine available languages (intersection between name translations and supported languages)
                     IEnumerable<string> languages = nameMulti.Languages.Intersect(settings.Localization.SupportedLanguages);

--- a/PxApi/Controllers/MetadataController.cs
+++ b/PxApi/Controllers/MetadataController.cs
@@ -15,7 +15,7 @@ namespace PxApi.Controllers
     /// Provides metadata endpoints for PX tables.
     /// </summary>
     [ApiKeyAuth]
-    [Route("meta")]
+    [Route("meta/databases")]
     [ApiController]
     public class MetadataController(ICachedDataSource cachedConnector, ILogger<MetadataController> logger, IAuditLogService auditLogService) : ControllerBase
     {
@@ -30,7 +30,7 @@ namespace PxApi.Controllers
         /// <response code="400">Requested language not available.</response>
         /// <response code="404">Database or table not found.</response>
         /// <response code="500">Unexpected server error.</response>
-        [HttpGet("{database}/{table}")]
+        [HttpGet("{database}/tables/{table}")]
         [OperationId("getTableMeta")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(JsonStat2), 200)]
@@ -120,7 +120,7 @@ namespace PxApi.Controllers
         /// <response code="400">Requested language not available.</response>
         /// <response code="404">Database or table not found.</response>
         /// <response code="500">Unexpected server error.</response>
-        [HttpHead("{database}/{table}")]
+        [HttpHead("{database}/tables/{table}")]
         [OperationId("headTableMeta")]
         [ProducesResponseType(200)]
         [ProducesResponseType(400)]
@@ -192,7 +192,7 @@ namespace PxApi.Controllers
         /// <param name="table">Identifier of the table.</param>
         /// <response code="200">Returns allowed methods in the Allow header.</response>
         /// <response code="500">Unexpected server error.</response>
-        [HttpOptions("{database}/{table}")]
+        [HttpOptions("{database}/tables/{table}")]
         [OperationId("optionsTableMeta")]
         [ProducesResponseType(200)]
         [ProducesResponseType(500)]

--- a/PxApi/Controllers/TablesController.cs
+++ b/PxApi/Controllers/TablesController.cs
@@ -110,7 +110,7 @@ namespace PxApi.Controllers
                             IReadOnlyMatrixMetadata tableMeta = await cachedConnector.GetMetadataCachedAsync(table.Value);
 
                             Uri fileUri = settings.RootUrl
-                                .AddRelativePath("meta", "databases", database, "tables", table.Key)
+                                .AddRelativePath("meta", "databases", dataBaseRef.Value.Id, "tables", table.Key)
                                 .AddQueryParameters(("lang", actualLang));
                             pagedTableList.Tables.Add(BuildTableListingItemFromMeta(table.Key, actualLang, tableMeta, fileUri));
 

--- a/PxApi/Controllers/TablesController.cs
+++ b/PxApi/Controllers/TablesController.cs
@@ -22,7 +22,7 @@ namespace PxApi.Controllers
     /// Supports pagination and optional language-based metadata retrieval. Tables are ordered by their PX file name (ascending). If the requested page exceeds the last page an empty list is returned.
     /// </remarks>
     [ApiKeyAuth]
-    [Route("tables")]
+    [Route("meta/databases")]
     [ApiController]
     public class TablesController(ICachedDataSource cachedConnector, ILogger<TablesController> logger, IAuditLogService auditLogger) : ControllerBase
     {
@@ -40,7 +40,7 @@ namespace PxApi.Controllers
         /// <response code="400">Invalid query parameter was provided (page &lt; 1, pageSize outside 1-100 or unsupported language).</response>
         /// <response code="404">Database not found.</response>
         /// <response code="500">Unexpected server error.</response>
-        [HttpGet("{database}")]
+        [HttpGet("{database}/tables")]
         [OperationId("listTables")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(PagedTableList), 200)]
@@ -110,7 +110,7 @@ namespace PxApi.Controllers
                             IReadOnlyMatrixMetadata tableMeta = await cachedConnector.GetMetadataCachedAsync(table.Value);
 
                             Uri fileUri = settings.RootUrl
-                                .AddRelativePath("meta", database, table.Key)
+                                .AddRelativePath("meta", "databases", database, "tables", table.Key)
                                 .AddQueryParameters(("lang", actualLang));
                             pagedTableList.Tables.Add(BuildTableListingItemFromMeta(table.Key, actualLang, tableMeta, fileUri));
 
@@ -142,7 +142,7 @@ namespace PxApi.Controllers
         /// <response code="400">Invalid paging parameters.</response>
         /// <response code="404">Database not found.</response>
         /// <response code="500">Unexpected server error.</response>
-        [HttpHead("{database}")]
+        [HttpHead("{database}/tables")]
         [OperationId("headTables")]
         [ProducesResponseType(200)]
         [ProducesResponseType(400)]
@@ -186,7 +186,7 @@ namespace PxApi.Controllers
         /// <response code="200">Returns allowed methods in the Allow header.</response>
         /// <response code="404">Database not found.</response>
         /// <response code="500">Unexpected server error.</response>
-        [HttpOptions("{database}")]
+        [HttpOptions("{database}/tables")]
         [OperationId("optionsTables")]
         [Produces("application/json")]
         [ProducesResponseType(200)]

--- a/PxApi/OpenApi/DocumentFilters/DataControllerGetEndpointDocumentFilter.cs
+++ b/PxApi/OpenApi/DocumentFilters/DataControllerGetEndpointDocumentFilter.cs
@@ -40,7 +40,7 @@ namespace PxApi.OpenApi.DocumentFilters
 
         private static bool IsDataControllerGetOperation(string pathKey, OpenApiOperation operation)
         {
-            bool isDataPath = pathKey.Equals("/data/{database}/{table}", StringComparison.OrdinalIgnoreCase);
+            bool isDataPath = pathKey.Equals("/data/databases/{database}/tables/{table}", StringComparison.OrdinalIgnoreCase);
             bool hasFiltersParam = operation.Parameters?.Any(p => p.Name == "filters") == true;
             return isDataPath && hasFiltersParam;
         }

--- a/PxApi/OpenApi/DocumentFilters/DataControllerPostEndpointDocumentFilter.cs
+++ b/PxApi/OpenApi/DocumentFilters/DataControllerPostEndpointDocumentFilter.cs
@@ -57,7 +57,7 @@ namespace PxApi.OpenApi.DocumentFilters
             IReadOnlyDictionary<string, OpenApiExample> examples = DataRequestBodyExamples.Examples;
             foreach (OpenApiMediaType mediaType in requestBody.Content.Values)
             {
-                mediaType.Examples = new Dictionary<string, IOpenApiExample>(examples.Select(kvp => 
+                mediaType.Examples = new Dictionary<string, IOpenApiExample>(examples.Select(kvp =>
                     new KeyValuePair<string, IOpenApiExample>(kvp.Key, kvp.Value)));
 
                 if (mediaType.Schema is OpenApiSchema schema &&
@@ -70,7 +70,7 @@ namespace PxApi.OpenApi.DocumentFilters
 
         private static bool IsDataControllerPostOperation(string pathKey, OpenApiOperation operation)
         {
-            bool isDataPath = pathKey.Equals("/data/{database}/{table}", StringComparison.OrdinalIgnoreCase);
+            bool isDataPath = pathKey.Equals("/data/databases/{database}/tables/{table}", StringComparison.OrdinalIgnoreCase);
             bool hasRequestBody = operation.RequestBody is OpenApiRequestBody rb && rb.Content?.Any() == true;
             return isDataPath && hasRequestBody;
         }

--- a/PxApi/OpenApi/DocumentFilters/DatabasesControllerGetEndpointDocumentFilter.cs
+++ b/PxApi/OpenApi/DocumentFilters/DatabasesControllerGetEndpointDocumentFilter.cs
@@ -6,13 +6,13 @@ using System.Diagnostics.CodeAnalysis;
 namespace PxApi.OpenApi.DocumentFilters
 {
     /// <summary>
-    /// Adds example response documentation for the DatabasesController GET /databases endpoint.
+    /// Adds example response documentation for the DatabasesController GET /meta/databases endpoint.
     /// </summary>
     [ExcludeFromCodeCoverage]
     public class DatabasesControllerGetEndpointDocumentFilter : IDocumentFilter
     {
         /// <summary>
-        /// Applies documentation enhancements to the /databases GET operation by injecting an example response.
+        /// Applies documentation enhancements to the /meta/databases GET operation by injecting an example response.
         /// </summary>
         /// <param name="swaggerDoc">OpenAPI document.</param>
         /// <param name="context">Filter context.</param>
@@ -25,7 +25,7 @@ namespace PxApi.OpenApi.DocumentFilters
 
             foreach (KeyValuePair<string, IOpenApiPathItem> path in swaggerDoc.Paths)
             {
-                if (path.Key.Equals("/databases", StringComparison.OrdinalIgnoreCase) &&
+                if (path.Key.Equals("/meta/databases", StringComparison.OrdinalIgnoreCase) &&
                     path.Value is OpenApiPathItem pathItem &&
                     pathItem.Operations != null &&
                     pathItem.Operations.TryGetValue(HttpMethod.Get, out OpenApiOperation? getOp))

--- a/PxApi/OpenApi/Examples/DatabaseListingExample.cs
+++ b/PxApi/OpenApi/Examples/DatabaseListingExample.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Nodes;
 namespace PxApi.OpenApi.Examples
 {
     /// <summary>
-    /// Provides an example array response for the GET /databases endpoint.
+    /// Provides an example array response for the GET /meta/databases endpoint.
     /// </summary>
     public static class DatabaseListingExample
     {

--- a/PxApi/OpenApi/Examples/DatabaseListingExample.cs
+++ b/PxApi/OpenApi/Examples/DatabaseListingExample.cs
@@ -11,7 +11,7 @@ namespace PxApi.OpenApi.Examples
     public static class DatabaseListingExample
     {
         private static string TablesHrefExample => AppSettings.Active.RootUrl
-            .AddRelativePath("tables", "StatFin")
+            .AddRelativePath("meta", "databases", "StatFin", "tables")
             .AddQueryParameters(("lang", "fi"))
             .ToString();
 

--- a/PxApi/PxApi.csproj
+++ b/PxApi/PxApi.csproj
@@ -5,7 +5,7 @@
    <Nullable>enable</Nullable>
    <ImplicitUsings>enable</ImplicitUsings>
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-   <Version>0.3.4</Version>
+   <Version>0.4.0</Version>
  </PropertyGroup>
 
  <ItemGroup>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
 # PxApi
 
-PxApi is a .NET 9.0 Web API for accessing PX statistical datasets. It provides table listings, table metadata and data retrieval with flexible dimension filtering and caching across multiple storage backends (local file system, Azure File Share, Azure Blob Storage).
+PxApi is a .NET 10.0 Web API for accessing PX statistical datasets. It provides table listings, table metadata and data retrieval with flexible dimension filtering and caching across multiple storage backends (local file system, Azure File Share, Azure Blob Storage).
 
 ## Implemented Features
 
-- Table listing with paging (`/tables/{database}`)
-- Table metadata in JSON-stat 2.0 (`/meta/{database}/{table}`)
-- Data retrieval with filter semantics (code, range, positional) via GET query parameters or POST body (`/data/{database}/{table}`)
+- Table listing with paging (`/meta/databases/{database}/tables`)
+- Table metadata in JSON-stat 2.0 (`/meta/databases/{database}/tables/{table}`)
+- Data retrieval with filter semantics (code, range, positional) via GET query parameters or POST body (`/data/databases/{database}/tables/{table}`)
 - Content negotiation (JSON-stat 2.0 or CSV) using the `Accept` header
-- Cache management endpoints (database level and single table) (`/cache/{database}` / `/cache/{database}/{id}`)
+- Cache management endpoints (database level and single table) (`/cache/databases/{database}` / `/cache/databases/{database}/tables/{id}`)
 - Global and per-database caching (file lists, metadata, data, last updated timestamps, grouping metadata)
 - Feature flags (Swagger visibility of cache endpoints)
 - Controller-specific API key authentication for all endpoints
@@ -20,7 +20,7 @@ PxApi is a .NET 9.0 Web API for accessing PX statistical datasets. It provides t
 ## Endpoints
 
 ### Databases
-`GET /databases?lang=fi`
+`GET /meta/databases?lang=fi`
 Returns a list of available databases with their metadata.
 
 **Authentication**: Requires valid API key in `X-Databases-API-Key` header when databases authentication is enabled.
@@ -34,11 +34,11 @@ Responses:
 - `401 Unauthorized` missing / invalid API key (when authentication configured)
 
 Additional methods:
-- `HEAD /databases` validates existence of the database collection resource
-- `OPTIONS /databases` returns Allow header (`GET,HEAD,OPTIONS`)
+- `HEAD /meta/databases` validates existence of the database collection resource
+- `OPTIONS /meta/databases` returns Allow header (`GET,HEAD,OPTIONS`)
 
 ### Tables
-`GET /tables/{database}?lang=fi&page=1&pageSize=50`
+`GET /meta/databases/{database}/tables?lang=fi&page=1&pageSize=50`
 Returns a paged list of tables ordered by PX file name.
 
 **Authentication**: Requires valid API key in `X-Tables-API-Key` header when tables authentication is enabled.
@@ -55,11 +55,11 @@ Responses:
 - `404 Not Found` database missing
 
 Additional methods:
-- `HEAD /tables/{database}` validates existence and paging values
-- `OPTIONS /tables/{database}` returns Allow header (`GET,HEAD,OPTIONS`)
+- `HEAD /meta/databases/{database}/tables` validates existence and paging values
+- `OPTIONS /meta/databases/{database}/tables` returns Allow header (`GET,HEAD,OPTIONS`)
 
 ### Metadata
-`GET /meta/{database}/{table}?lang=fi`
+`GET /meta/databases/{database}/tables/{table}?lang=fi`
 Returns JSON-stat 2.0 metadata (structure only, no data filtering).
 
 **Authentication**: Requires valid API key in `X-Metadata-API-Key` header when metadata authentication is enabled.
@@ -75,11 +75,11 @@ Responses:
 - `500 Internal Server Error` unexpected error
 
 Additional methods:
-- `HEAD /meta/{database}/{table}` existence & language validation only
-- `OPTIONS /meta/{database}/{table}` returns Allow header (`GET,HEAD,OPTIONS`)
+- `HEAD /meta/databases/{database}/tables/{table}` existence & language validation only
+- `OPTIONS /meta/databases/{database}/tables/{table}` returns Allow header (`GET,HEAD,OPTIONS`)
 
 ### Data
-`GET /data/{database}/{table}?filters=TIME:from=2020&filters=TIME:to=2024&filters=REGION:code=001,002`
+`GET /data/databases/{database}/tables/{table}?filters=TIME:from=2020&filters=TIME:to=2024&filters=REGION:code=001,002`
 
 Retrieves data values applying filters to dimensions. Content negotiation support for json and csv:
 
@@ -109,7 +109,7 @@ Rules:
 - Wildcard `*` matches zero or more characters in code/from/to values.
 
 POST alternative:
-`POST /data/{database}/{table}` with JSON body mapping dimension codes to filter objects.
+`POST /data/databases/{database}/tables/{table}` with JSON body mapping dimension codes to filter objects.
 Example body:
 ```json
 {
@@ -131,16 +131,16 @@ Responses (GET & POST):
 - `415 Unsupported Media Type` (POST invalid content type)
 
 Additional methods:
-- `HEAD /data/{database}/{table}?lang=fi` existence & language validation only
-- `OPTIONS /data/{database}/{table}` returns Allow header (`GET,POST,HEAD,OPTIONS`)
+- `HEAD /data/databases/{database}/tables/{table}?lang=fi` existence & language validation only
+- `OPTIONS /data/databases/{database}/tables/{table}` returns Allow header (`GET,POST,HEAD,OPTIONS`)
 
 ### Cache
 Requires feature flag `CacheController = true` and valid API key when authentication is enabled.
 
 **Authentication**: Requires valid API key in `X-Cache-API-Key` header when cache authentication is enabled.
 
-- `DELETE /cache/{database}` clears all cache entries (file list, metadata, data, last updated) for a database.
-- `DELETE /cache/{database}/{id}` clears all cache entries for a single table.
+- `DELETE /cache/databases/{database}` clears all cache entries (file list, metadata, data, last updated) for a database.
+- `DELETE /cache/databases/{database}/tables/{id}` clears all cache entries for a single table.
 
 Responses:
 - `200 OK` success message


### PR DESCRIPTION
## Restructure API endpoint paths to hierarchical resource URLs

### Description

Restructures all API endpoint paths to follow a consistent hierarchical REST resource pattern by introducing explicit `/databases/{database}/tables/{table}` segments. This makes the URL structure self-describing and prepares the API for future sub-resource endpoints (e.g. dimensions, values).

### Route changes

| Controller | Before | After |
|---|---|---|
| Databases | GET /databases | GET /meta/databases |
| Tables | GET /tables/{database} | GET /meta/databases/{database}/tables |
| Metadata | GET /meta/{database}/{table} | GET /meta/databases/{database}/tables/{table} |
| Data | GET,POST /data/{database}/{table} | GET,POST /data/databases/{database}/tables/{table} |
| Cache | DELETE /cache/{database}/{id} | DELETE /cache/databases/{database}/tables/{id} |

### What changed

- 5 controllers — Updated [Route] class-level prefixes and [Http*] action-level route templates
- HATEOAS links — Updated link generation in DatabasesController and TablesController to produce correct hrefs for the new paths
- OpenAPI document filters — Updated path matching in DataControllerGetEndpointDocumentFilter and DataControllerPostEndpointDocumentFilter
- OpenAPI examples — Updated DatabaseListingExample href to match the new table listing path
- XML doc comments — Updated to reference the new endpoint paths
- Tests — Updated all affected unit test assertions to expect the new paths; fixed minor SonarQube issues (empty statements, extracted string constants)