### PR TITLE
[Dependency] Update vulnerable dependencies

### DIFF
--- a/PxApi.UnitTests/PxApi.UnitTests.csproj
+++ b/PxApi.UnitTests/PxApi.UnitTests.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="Px.Utils" Version="1.4.0" />
   </ItemGroup>
 

--- a/PxApi/PxApi.csproj
+++ b/PxApi/PxApi.csproj
@@ -20,7 +20,7 @@
    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.25.0" />
    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.17.3" />
-   <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.0.0" />
+   <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
@@ -32,6 +32,6 @@
    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.5" />
    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.5" />
    <PackageReference Include="Ude.NetStandard" Version="1.2.0" />
+   <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
  </ItemGroup>
-
 </Project>

--- a/PxApi/PxApi.csproj
+++ b/PxApi/PxApi.csproj
@@ -5,7 +5,7 @@
    <Nullable>enable</Nullable>
    <ImplicitUsings>enable</ImplicitUsings>
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-   <Version>0.5.0</Version>
+   <Version>0.5.1</Version>
  </PropertyGroup>
 
  <ItemGroup>
@@ -27,11 +27,11 @@
    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
    <PackageReference Include="NLog" Version="6.1.1" />
    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
+   <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
    <PackageReference Include="Px.Utils" Version="1.4.0" />
    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.5" />
    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.5" />
    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.5" />
    <PackageReference Include="Ude.NetStandard" Version="1.2.0" />
-   <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
  </ItemGroup>
 </Project>


### PR DESCRIPTION
Update ApplicationInsights.AspNetCore dependency and install OpenTelemetry.Api with an explicitly safe version