### PR TITLE
Refactor SearchController feature flag in Health tests

### DIFF
--- a/PxApi.UnitTests/ControllerTests/HealthControllerTests.cs
+++ b/PxApi.UnitTests/ControllerTests/HealthControllerTests.cs
@@ -28,6 +28,7 @@ namespace PxApi.UnitTests.ControllerTests
 
             Dictionary<string, string?> configData = TestConfigFactory.Merge(
                 TestConfigFactory.Base(),
+                new Dictionary<string, string?> { ["FeatureManagement:SearchController"] = "true" },
                 TestConfigFactory.MountedDb(0, "db1", "datasource/root1/"),
                 TestConfigFactory.MountedDb(1, "db2", "datasource/root2/")
             );
@@ -118,7 +119,10 @@ namespace PxApi.UnitTests.ControllerTests
         public async Task GetHealth_NoDatabases_ReturnsOkWithHealthyStatus()
         {
             // Arrange - config with no databases
-            Dictionary<string, string?> configData = TestConfigFactory.Base();
+            Dictionary<string, string?> configData = TestConfigFactory.Merge(
+                TestConfigFactory.Base(),
+                new Dictionary<string, string?> { ["FeatureManagement:SearchController"] = "true" }
+            );
             TestConfigFactory.BuildAndLoad(configData);
 
             _services.AddScoped<ISearchService>(_ => _mockSearchService.Object);

--- a/PxApi.UnitTests/Utils/TestConfigFactory.cs
+++ b/PxApi.UnitTests/Utils/TestConfigFactory.cs
@@ -23,7 +23,7 @@ namespace PxApi.UnitTests.Utils
                 ["Cache:DefaultFileListSize"] = "350000",
                 ["Cache:DefaultMetaSize"] = "200000",
                 ["FeatureManagement:CacheController"] = "true",
-                ["FeatureManagement:SearchController"] = "true",
+                ["FeatureManagement:SearchController"] = "false",
                 ["QueryLimits:JsonMaxCells"] = "100000",
                 ["QueryLimits:JsonStatMaxCells"] = "50000",
                 ["Localization:DefaultLanguage"] = "fi",


### PR DESCRIPTION
Set "FeatureManagement:SearchController" to false in the base test config. Tests that require it now explicitly enable the flag by merging it into their config, making feature usage explicit and improving test clarity.