### PR TITLE
[Bug] Code filter deserialisation

### DIFF
--- a/PxApi.UnitTests/Models/QueryFilters/FilterJsonConverterTests.cs
+++ b/PxApi.UnitTests/Models/QueryFilters/FilterJsonConverterTests.cs
@@ -81,10 +81,20 @@ namespace PxApi.UnitTests.Models.QueryFilters
         }
 
         [Test]
+        public void Deserialize_CodeFilter_WithAllAllowedSpecialChars_Succeeds()
+        {
+            const string json = "{\"type\":\"Code\",\"query\":[\"A*B_C-D.E\"]}";
+            Filter? filter = JsonSerializer.Deserialize<Filter>(json, _options);
+            Assert.That(filter, Is.TypeOf<CodeFilter>());
+            CodeFilter codeFilter = (CodeFilter)filter!;
+            Assert.That(codeFilter.FilterStrings[0], Is.EqualTo("A*B_C-D.E"));
+        }
+
+        [Test]
         public void Deserialize_CodeFilter_WithInvalidCharacter_Throws()
         {
             const string json = "{\"type\":\"Code\",\"query\":[\"Valid\",\"In!valid\"]}"; // '!' not allowed
-            Assert.That(() => JsonSerializer.Deserialize<Filter>(json, _options), Throws.ArgumentException);
+            Assert.That(() => JsonSerializer.Deserialize<Filter>(json, _options), Throws.InstanceOf<JsonException>());
         }
 
         [Test]
@@ -92,7 +102,7 @@ namespace PxApi.UnitTests.Models.QueryFilters
         {
             string longString = new('a', 51);
             string json = $"{{\"type\":\"Code\",\"query\":[\"{longString}\"]}}";
-            Assert.That(() => JsonSerializer.Deserialize<Filter>(json, _options), Throws.ArgumentException);
+            Assert.That(() => JsonSerializer.Deserialize<Filter>(json, _options), Throws.InstanceOf<JsonException>());
         }
 
         private static bool JsonEquals(string a, string b)

--- a/PxApi.UnitTests/Models/QueryFilters/FilterJsonConverterTests.cs
+++ b/PxApi.UnitTests/Models/QueryFilters/FilterJsonConverterTests.cs
@@ -105,6 +105,13 @@ namespace PxApi.UnitTests.Models.QueryFilters
             Assert.That(() => JsonSerializer.Deserialize<Filter>(json, _options), Throws.InstanceOf<JsonException>());
         }
 
+        [Test]
+        public void Deserialize_UnknownTypeFilter_Throws()
+        {
+            const string json = "{\"type\":\"Unknown\",\"query\":\"test\"}";
+            Assert.That(() => JsonSerializer.Deserialize<Filter>(json, _options), Throws.InstanceOf<JsonException>());
+        }
+
         private static bool JsonEquals(string a, string b)
         {
             using JsonDocument ja = JsonDocument.Parse(a);

--- a/PxApi/Models/QueryFilters/FilterJsonConverter.cs
+++ b/PxApi/Models/QueryFilters/FilterJsonConverter.cs
@@ -122,7 +122,7 @@ namespace PxApi.Models.QueryFilters
                         int lastCount = filterWrapper.Query.Deserialize<int>(options);
                         return new LastFilter(lastCount);
                     }
-                default: throw new InvalidOperationException("Unknown filter type: " + filterWrapper.Type);
+                default: throw new JsonException("Unknown filter type: " + filterWrapper.Type);
             }
         }
 

--- a/PxApi/Models/QueryFilters/FilterJsonConverter.cs
+++ b/PxApi/Models/QueryFilters/FilterJsonConverter.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -88,6 +90,7 @@ namespace PxApi.Models.QueryFilters
         }
 
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage(Justification = "Default case is unreachable: JsonStringEnumConverter throws JsonException for unknown FilterType values before the switch is evaluated.")]
         public override Filter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             FilterJsonModel? filterWrapper = JsonSerializer.Deserialize<FilterJsonModel>(ref reader, options);
@@ -122,7 +125,7 @@ namespace PxApi.Models.QueryFilters
                         int lastCount = filterWrapper.Query.Deserialize<int>(options);
                         return new LastFilter(lastCount);
                     }
-                default: throw new JsonException("Unknown filter type: " + filterWrapper.Type);
+                default: throw new UnreachableException("Unknown filter type: " + filterWrapper.Type);
             }
         }
 

--- a/PxApi/Models/QueryFilters/FilterJsonConverter.cs
+++ b/PxApi/Models/QueryFilters/FilterJsonConverter.cs
@@ -130,16 +130,16 @@ namespace PxApi.Models.QueryFilters
         {
             if (input.Length > 50)
             {
-                throw new ArgumentException("Filter string exceeds maximum length of 50 characters");
+                throw new JsonException("Filter string exceeds maximum length of 50 characters");
             }
 
-            char[] allowedSpecialChars = ['*', '_', '-'];
+            char[] allowedSpecialChars = ['*', '_', '-', '.'];
 
             foreach (char c in input)
             {
                 if (!char.IsLetterOrDigit(c) && !allowedSpecialChars.Contains(c))
                 {
-                    throw new ArgumentException("Input string contains characters other than letters, numbers, '*', '_' and '-'");
+                    throw new JsonException("Input string contains characters other than letters, numbers, '*', '_', '-' and '.'");
                 }
             }
         }

--- a/PxApi/PxApi.csproj
+++ b/PxApi/PxApi.csproj
@@ -5,7 +5,7 @@
    <Nullable>enable</Nullable>
    <ImplicitUsings>enable</ImplicitUsings>
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-   <Version>0.5.4</Version>
+   <Version>0.5.5</Version>
  </PropertyGroup>
 
  <ItemGroup>


### PR DESCRIPTION
Added '.' to the list of allowed special characters for code filter deserialisation.
Failed code filter deserialisation throws JsonException now to be caught by the ErrorController.
Added and updated tests to cover the changes.