### PR TITLE
[Feature] TableSummary "geo" property

### DIFF
--- a/PxApi.UnitTests/UtilitiesTests/TableSummaryBuilderTests.cs
+++ b/PxApi.UnitTests/UtilitiesTests/TableSummaryBuilderTests.cs
@@ -51,7 +51,7 @@ namespace PxApi.UnitTests.UtilitiesTests
                 Assert.That(summaryEn.Metrics, Has.Count.EqualTo(2));
                 Assert.That(summaryEn.TimeRange.From, Is.EqualTo("time-value0-name.en"));
                 Assert.That(summaryEn.TimeRange.To, Is.EqualTo("time-value1-name.en"));
-                Assert.That(summaryEn.Dimensions, Has.Count.EqualTo(3));
+                Assert.That(summaryEn.Dimensions, Has.Count.EqualTo(2));
                 Assert.That(summaryEn.LastUpdated, Is.EqualTo(new DateTime(2024, 10, 10, 0, 0, 0, DateTimeKind.Utc)));
                 Assert.That(summaryEn.Geo, Is.Not.Null);
                 Assert.That(summaryEn.Geo, Is.EqualTo("dim2-name.en"));
@@ -62,7 +62,7 @@ namespace PxApi.UnitTests.UtilitiesTests
                 Assert.That(summaryFi.Metrics, Has.Count.EqualTo(2));
                 Assert.That(summaryFi.TimeRange.From, Is.EqualTo("time-value0-name.fi"));
                 Assert.That(summaryFi.TimeRange.To, Is.EqualTo("time-value1-name.fi"));
-                Assert.That(summaryFi.Dimensions, Has.Count.EqualTo(3));
+                Assert.That(summaryFi.Dimensions, Has.Count.EqualTo(2));
                 Assert.That(summaryFi.LastUpdated, Is.EqualTo(new DateTime(2024, 10, 10, 0, 0, 0, DateTimeKind.Utc)));
                 Assert.That(summaryFi.Geo, Is.Not.Null);
                 Assert.That(summaryFi.Geo, Is.EqualTo("dim2-name.fi"));

--- a/PxApi.UnitTests/UtilitiesTests/TableSummaryBuilderTests.cs
+++ b/PxApi.UnitTests/UtilitiesTests/TableSummaryBuilderTests.cs
@@ -1,5 +1,6 @@
 using Px.Utils.Models.Metadata;
 using Px.Utils.Models.Metadata.Dimensions;
+using Px.Utils.Models.Metadata.Enums;
 using PxApi.Models;
 using PxApi.UnitTests.ModelBuilderTests;
 using PxApi.Utilities;
@@ -28,6 +29,43 @@ namespace PxApi.UnitTests.UtilitiesTests
                 Assert.That(summary.TimeRange.To, Is.EqualTo("time-value1-name.en"));
                 Assert.That(summary.Dimensions, Has.Count.EqualTo(2));
                 Assert.That(summary.LastUpdated, Is.EqualTo(new DateTime(2024, 10, 10, 0, 0, 0, DateTimeKind.Utc)));
+                Assert.That(summary.Geo, Is.Null);
+            }
+        }
+
+        [Test]
+        public void Build_ValidMetadataWithGeoDimension_ReturnsSummary()
+        {
+            // Arrange
+            MatrixMetadata metadata = TestMockMetaBuilder.GetMockMetadata([DimensionType.Geographical]);
+
+            // Act
+            TableSummary summaryFi = TableSummaryBuilder.Build(metadata, "table1", "fi");
+            TableSummary summaryEn = TableSummaryBuilder.Build(metadata, "table1", "en");
+
+            // Assert
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(summaryEn.TableId, Is.EqualTo("table-tableid"));
+                Assert.That(summaryEn.Title, Is.EqualTo("table-description.en"));
+                Assert.That(summaryEn.Metrics, Has.Count.EqualTo(2));
+                Assert.That(summaryEn.TimeRange.From, Is.EqualTo("time-value0-name.en"));
+                Assert.That(summaryEn.TimeRange.To, Is.EqualTo("time-value1-name.en"));
+                Assert.That(summaryEn.Dimensions, Has.Count.EqualTo(3));
+                Assert.That(summaryEn.LastUpdated, Is.EqualTo(new DateTime(2024, 10, 10, 0, 0, 0, DateTimeKind.Utc)));
+                Assert.That(summaryEn.Geo, Is.Not.Null);
+                Assert.That(summaryEn.Geo, Is.EqualTo("dim2-name.en"));
+
+
+                Assert.That(summaryFi.TableId, Is.EqualTo("table-tableid"));
+                Assert.That(summaryFi.Title, Is.EqualTo("table-description.fi"));
+                Assert.That(summaryFi.Metrics, Has.Count.EqualTo(2));
+                Assert.That(summaryFi.TimeRange.From, Is.EqualTo("time-value0-name.fi"));
+                Assert.That(summaryFi.TimeRange.To, Is.EqualTo("time-value1-name.fi"));
+                Assert.That(summaryFi.Dimensions, Has.Count.EqualTo(3));
+                Assert.That(summaryFi.LastUpdated, Is.EqualTo(new DateTime(2024, 10, 10, 0, 0, 0, DateTimeKind.Utc)));
+                Assert.That(summaryFi.Geo, Is.Not.Null);
+                Assert.That(summaryFi.Geo, Is.EqualTo("dim2-name.fi"));
             }
         }
 

--- a/PxApi/Models/TableSummary.cs
+++ b/PxApi/Models/TableSummary.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace PxApi.Models
 {
@@ -44,5 +45,11 @@ namespace PxApi.Models
         /// </summary>
         [Required]
         public required DateTime LastUpdated { get; set; }
+
+        /// <summary>
+        /// Name of the geographical dimension if it exists, otherwise null.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Geo { get; set; } = null;
     }
 }

--- a/PxApi/Models/TableSummary.cs
+++ b/PxApi/Models/TableSummary.cs
@@ -35,7 +35,7 @@ namespace PxApi.Models
         public required TimeRange TimeRange { get; set; }
 
         /// <summary>
-        /// Names and sizes of all dimensions, excluding the metric and time dimensions.
+        /// Names and sizes of all dimensions, excluding the metric, time, and geographical dimensions.
         /// </summary>
         [Required]
         public required List<DimensionInfo> Dimensions { get; set; }

--- a/PxApi/PxApi.csproj
+++ b/PxApi/PxApi.csproj
@@ -5,7 +5,7 @@
    <Nullable>enable</Nullable>
    <ImplicitUsings>enable</ImplicitUsings>
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-   <Version>0.5.5</Version>
+   <Version>0.5.6</Version>
  </PropertyGroup>
 
  <ItemGroup>

--- a/PxApi/Utilities/TableSummaryBuilder.cs
+++ b/PxApi/Utilities/TableSummaryBuilder.cs
@@ -1,5 +1,6 @@
 using Px.Utils.Models.Metadata;
 using Px.Utils.Models.Metadata.Dimensions;
+using Px.Utils.Models.Metadata.Enums;
 using Px.Utils.Models.Metadata.ExtensionMethods;
 using PxApi.ModelBuilders;
 using PxApi.Models;
@@ -44,6 +45,7 @@ namespace PxApi.Utilities
                     Size = dimension.Values.Count
                 })
                 .ToList();
+            string? geo = metadata.Dimensions.Where(dim => dim.Type == DimensionType.Geographical).Select(dim => dim.Name[lang]).FirstOrDefault();
 
             return new TableSummary
             {
@@ -52,7 +54,8 @@ namespace PxApi.Utilities
                 Metrics = metrics,
                 TimeRange = timeRange,
                 Dimensions = dimensions,
-                LastUpdated = lastUpdated
+                LastUpdated = lastUpdated,
+                Geo = geo
             };
         }
 

--- a/PxApi/Utilities/TableSummaryBuilder.cs
+++ b/PxApi/Utilities/TableSummaryBuilder.cs
@@ -37,15 +37,16 @@ namespace PxApi.Utilities
 
             DateTime lastUpdated = contentDimension.Values.Map(value => value.LastUpdated).Max();
             TimeRange timeRange = BuildTimeRange(metadata, lang);
+            IReadOnlyDimension? geoDimension = metadata.Dimensions.FirstOrDefault(dim => dim.Type == DimensionType.Geographical);
+            string? geo = geoDimension?.Name[lang];
             List<DimensionInfo> dimensions = metadata.Dimensions
-                .Where(dimension => dimension is not ContentDimension && dimension is not TimeDimension)
+                .Where(dimension => dimension is not ContentDimension && dimension is not TimeDimension && dimension != geoDimension)
                 .Select(dimension => new DimensionInfo
                 {
                     Name = dimension.Name[lang],
                     Size = dimension.Values.Count
                 })
                 .ToList();
-            string? geo = metadata.Dimensions.Where(dim => dim.Type == DimensionType.Geographical).Select(dim => dim.Name[lang]).FirstOrDefault();
 
             return new TableSummary
             {

--- a/docs/architecture/models-and-builders.md
+++ b/docs/architecture/models-and-builders.md
@@ -16,7 +16,7 @@ These types are used throughout routing, connectors, and caching for type-safe, 
 - **`DataBaseListingItem`** (`DataBaseListingItem.cs`): Database metadata for the `/meta/databases` response (name, description, language list, table count, links).
 - **`PagedTableList`** (`PagedTableList.cs`): Paginated table listing wrapper with paging metadata.
 - **`TableListingItem`** (`TableListingItem.cs`): Minimal table info for listing responses.
-- **`TableSummary`** (`TableSummary.cs`): Rich table metadata summary including dimensions, content values, time ranges, and links. Built by `TableSummaryBuilder`.
+- **`TableSummary`** (`TableSummary.cs`): Rich table metadata summary including dimensions, content values, time ranges, geographical dimension name, and links. Built by `TableSummaryBuilder`.
 - **`ContentValueInfo`** (`ContentValueInfo.cs`): Information about a content/measure value in a table.
 - **`DimensionInfo`** (`DimensionInfo.cs`): Dimension metadata (code, name, type, value count).
 - **`TimeRange`** (`TimeRange.cs`): Start/end time period for a time dimension.

--- a/docs/architecture/services-and-utilities.md
+++ b/docs/architecture/services-and-utilities.md
@@ -52,7 +52,7 @@ Part of the composition root. Registers one keyed `IDataBaseConnector` per confi
 
 **File**: `PxApi/Utilities/TableSummaryBuilder.cs`
 
-Builds compact `TableSummary` DTOs from parsed PX metadata. Used by `TablesController` and `SearchController` to produce consistent table summary representations. Populates the `Geo` property with the localized name of the geographical dimension when one is present, otherwise leaves it `null`.
+Builds compact `TableSummary` DTOs from parsed PX metadata. Used by `TablesController` and `SearchController` to produce consistent table summary representations.
 
 ### QueryFilterUtils
 

--- a/docs/architecture/services-and-utilities.md
+++ b/docs/architecture/services-and-utilities.md
@@ -52,7 +52,7 @@ Part of the composition root. Registers one keyed `IDataBaseConnector` per confi
 
 **File**: `PxApi/Utilities/TableSummaryBuilder.cs`
 
-Builds compact `TableSummary` DTOs from parsed PX metadata. Used by `TablesController` and `SearchController` to produce consistent table summary representations.
+Builds compact `TableSummary` DTOs from parsed PX metadata. Used by `TablesController` and `SearchController` to produce consistent table summary representations. Populates the `Geo` property with the localized name of the geographical dimension when one is present, otherwise leaves it `null`.
 
 ### QueryFilterUtils
 


### PR DESCRIPTION
Populates nullable geo string property for TableSummary with geographical dimension name in given language if applicable.

Tests and documentation updated to cover changes.